### PR TITLE
Изменение цвета Бэкграунда иконки при наведении

### DIFF
--- a/dashboard/incl/cvolton.css
+++ b/dashboard/incl/cvolton.css
@@ -872,6 +872,6 @@ audio::-webkit-media-controls-toggle-closed-captions-button {
 	width: calc(100% - 8px);
 }
 button > .icon:hover {
-	background: #47494e !important;
+	background: #a9ccef !important;
 	cursor: pointer;
 }

--- a/dashboard/incl/cvolton.css
+++ b/dashboard/incl/cvolton.css
@@ -875,3 +875,8 @@ button > .icon:hover {
 	background: #a9ccef !important;
 	cursor: pointer;
 }
+
+.dropdown-item > .icon:hover {
+	background: #8abfff !important;
+	cursor: pointer;
+}


### PR DESCRIPTION
Баг при котором при наводке на иконку или области возле неё цвет фона изменялся на более серый

Было :
![image](https://user-images.githubusercontent.com/84383235/219087797-1ab6f34d-1441-4a92-bef6-64b499be808a.png)

Стало :
![image](https://user-images.githubusercontent.com/84383235/219087832-becd9dfc-f779-4f2a-8a9f-0a23555d3df6.png)
