### PR TITLE
Order Map Packs by Star Count

### DIFF
--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -13,8 +13,6 @@ $SFXsize = 4.5; // Max SFX size in megabytes
 $timeType = 1; // How time will show in-game, 0 - default Cvolton time, 1 - Dashboard-like time, 2 - RobTop-like time
 // If you changed dashboard's place, change $dbPath in dashboard/incl/dashboardLib.php
 
-$sakujes = true; // false = don't rename everyone to sakujes in the leaderboard on april 1st, false = rename everyone to sakujes in the leaderboard on april 1st
- 
 // External download links, disables when you have gdpsName.gdpsFileType in dashboard/download directory
 
 $pc = '';

--- a/config/misc.php
+++ b/config/misc.php
@@ -1,0 +1,5 @@
+<?php
+$orderMapPacksByStars = true; // true = in-game, order map packs by difficulty, false = in-game, order map packs by the date when they were created (newest to oldest)
+
+$sakujes = true; // false = don't rename everyone to sakujes in the leaderboard on april 1st, false = rename everyone to sakujes in the leaderboard on april 1st
+?>

--- a/incl/levelpacks/getGJMapPacks.php
+++ b/incl/levelpacks/getGJMapPacks.php
@@ -2,13 +2,17 @@
 chdir(dirname(__FILE__));
 //error_reporting(0);
 include "../lib/connection.php";
+include "../../config/misc.php";
 require_once "../lib/exploitPatch.php";
 require "../lib/generateHash.php";
+if(!isset($orderMapPacksByStars)) global $orderMapPacksByStars;
+
 $page = ExploitPatch::remove($_POST["page"]);
 $packpage = $page*10;
 $mappackstring = "";
 $lvlsmultistring = "";
-$query = $db->prepare("SELECT colors2,rgbcolors,ID,name,levels,stars,coins,difficulty FROM `mappacks` ORDER BY `ID` ASC LIMIT 10 OFFSET $packpage");
+if ($orderMapPacksByStars) $query = $db->prepare("SELECT colors2, rgbcolors, ID, name, levels, stars, coins, difficulty FROM `mappacks` ORDER BY `stars` ASC LIMIT 10 OFFSET $packpage");
+else $query = $db->prepare("SELECT colors2, rgbcolors, ID, name, levels, stars, coins, difficulty FROM `mappacks` ORDER BY `ID` ASC LIMIT 10 OFFSET $packpage");
 $query->execute();
 $result = $query->fetchAll();
 $packcount = $query->rowCount();

--- a/incl/scores/getGJScores.php
+++ b/incl/scores/getGJScores.php
@@ -1,10 +1,10 @@
 <?php
 chdir(dirname(__FILE__));
 include "../lib/connection.php";
+include "../../config/misc.php";
 require_once "../lib/exploitPatch.php";
 require_once "../lib/GJPCheck.php";
 require_once "../lib/mainLib.php";
-include "../../config/dashboard.php";
 if(!isset($sakujes)) global $sakujes;
 $gs = new mainLib();
 $stars = 0;


### PR DESCRIPTION
Add an option to order map packs by their star count

----------
Changelog:
- Added the `orderMapPacksByStars` toggle (`config/misc.php`)
- Moved the `sakujes` toggle (`config/dashboard.php` -> `config/misc.php`)
- Modified the include function to point to the new `sakujes` toggle location (`incl/scores/getGJScores.php`)
- Order map packs by stars if the toggle is enabled (`incl/levelpacks/getGJMapPacks.php`)