### PR TITLE
Add auto-like feature for specific commentIDs

### DIFF
--- a/config/misc.php
+++ b/config/misc.php
@@ -36,4 +36,12 @@ $minBinaryVersion = 0;
 $maxBinaryVersion = 0;
 
 $showAllLevels = false; // true => Shows all levels like robtop, even if the client can't support it || false => Only shows levels supported by client
+
+// New configurations for comment auto-like feature
+$commentAutoLike = false; // true = auto-like is enabled, false = auto-like is disabled
+$specialCommentLikes = [
+    1 => 10, // commentID => multiplier
+    2 => 20, // another commentID => multiplier
+    // Add more comment IDs and their multipliers as needed
+];
 ?>

--- a/incl/comments/getGJComments.php
+++ b/incl/comments/getGJComments.php
@@ -70,7 +70,11 @@ foreach($result as &$comment1) {
 		$commentText = ($gameVersion < 20) ? base64_decode($comment1["comment"]) : $comment1["comment"];
 		if($enableCommentLengthLimiter) $commentText = base64_encode(substr(base64_decode($commentText), 0, $maxCommentLength));
 		if($displayLevelID) $commentstring .= "1~".$comment1["levelID"]."~";
-		$likes = $comment1["likes"]; // - $comment1["dislikes"];
+		if ($commentAutoLike && array_key_exists($comment1["commentID"], $specialCommentLikes)) {
+                    $likes = $comment1["likes"] * $specialCommentLikes[$comment1["commentID"]]; // Multiply by the specified value
+                } else {
+                    $likes = $comment1["likes"]; // Normal like value
+                }
 		if($likes < -2) $comment1["isSpam"] = 1;
 		$commentstring .= "2~".$commentText."~3~".$comment1["userID"]."~4~".$likes."~5~0~7~".$comment1["isSpam"]."~9~".$uploadDate."~6~".$comment1["commentID"]."~10~".$comment1["percent"];
 		if ($comment1['userName']) { //TODO: get rid of queries caused by getMaxValuePermission and getAccountCommentColor


### PR DESCRIPTION
This commit adds a new feature to auto-increment the likes for specific commentIDs as defined in misc.php. The auto-like feature can be toggled on or off using the $commentAutoLike variable, and the specific commentIDs and their like multipliers are specified in the $specialCommentLikes array. The functionality is integrated into the main PHP file to check these settings and apply the appropriate like multiplier during comment retrieval.

Thanks for idea:

<img width="326" alt="Immagine 2024-06-01 023151" src="https://github.com/MegaSa1nt/GMDprivateServer/assets/164776965/28896dd4-d877-4c5d-a3b6-832f7c68d436">

- Include misc.php for accessing configuration settings;
- Add logic to apply like multiplier for specified commentIDs;
- Ensure normal like behavior when auto-like is disabled.