### PR TITLE
Possible sfx library fix for 2.206

### DIFF
--- a/incl/lib/mainLib.php
+++ b/incl/lib/mainLib.php
@@ -926,10 +926,17 @@ class mainLib {
 		}
 		$updatedLib = false;
 		foreach($servers AS $key => &$server) {
+			if ($types[$type] == 'music') {
+			    $versionUrl = $server.'/'.$types[$type].'/'.$types[$type].'library_version_02.txt';
+			    $dataUrl = $server.'/'.$types[$type].'/'.$types[$type].'library_02.dat';
+			} else {
+			    $versionUrl = $server.'/'.$types[$type].'/'.$types[$type].'library_version.txt';
+			    $dataUrl = $server.'/'.$types[$type].'/'.$types[$type].'library.dat';
+			}
 			if(file_exists(__DIR__.'/../../'.$types[$type].'/'.$key.'.txt')) $oldVersion = explode(', ', file_get_contents(__DIR__.'/../../'.$types[$type].'/'.$key.'.txt'));
 			else $oldVersion = [0, 0];
 			if($oldVersion[1] + 600 > time()) continue; // Download library only once per 10 minutes
-			$curl = curl_init($server.'/'.$types[$type].'/'.$types[$type].'library_version_02.txt?token='.$token.'&expires='.$expires);
+			$curl = curl_init($versionUrl.'?token='.$token.'&expires='.$expires);
 			curl_setopt_array($curl, [
 				CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
 				CURLOPT_RETURNTRANSFER => 1
@@ -938,7 +945,7 @@ class mainLib {
 			curl_close($curl);
 			if($newVersion > $oldVersion[0]) {
 				file_put_contents(__DIR__.'/../../'.$types[$type].'/'.$key.'.txt', $newVersion.', '.time());
-				$download = curl_init($server.'/'.$types[$type].'/'.$types[$type].'library_02.dat?token='.$token.'&expires='.$expires.'&dashboard=1');
+				$download = curl_init($dataUrl.'?token='.$token.'&expires='.$expires.'&dashboard=1');
 				curl_setopt_array($download, [
 					CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
 					CURLOPT_RETURNTRANSFER => 1


### PR DESCRIPTION
In order to accommodate potential changes for enabling access to the game's SFX library in Geometry Dash version 2.206, adjustments have been made to the `updateLibraries` function. The update involves separating the versioning not only for the music library (`musiclibrary_version_02.txt` and `musiclibrary_02.dat`) but also for the SFX library (`sfxlibrary_version.txt` and `sfxlibrary.dat`) without the _02 suffix. This change ensures compatibility with SFX, as the game does not support the _02 version of the SFX library. Therefore, supporting both the music and SFX libraries under the _02 version would be illogical if the SFX library does not support it. Before any publication I already tested whether the sfx library worked, as well as the music library and the modification was successful.

Then choose you how to distribute SFX and music libraries separately without combining them into a single version that the game does not accept, if in case this commit is not good for you!