### PR TITLE
Fix regex delimiter in rucharclean/exploitPatch.php

### DIFF
--- a/incl/lib/exploitPatch.php
+++ b/incl/lib/exploitPatch.php
@@ -8,9 +8,9 @@ class ExploitPatch {
 		if($trim != 0) return mb_substr(preg_replace("/[^A-Za-z0-9 ]/", '', $string), 0, $trim);
 		else return preg_replace("/[^A-Za-z0-9 ]/", '', $string);
 	}
- 	public static function rucharclean($string, $trim = 0) {
-		if($trim != 0) return mb_substr(mb_ereg_replace("[^A-Za-zА-Яа-я0-9\[\]\!\.\?\(\)\,\@\#\%\:\*\=\+\-\—ёЁ\/ ]", '', $string), 0, $trim);
-		else return mb_ereg_replace("[^A-Za-zА-Яа-я0-9\[\]\!\.\?\(\)\,\@\#\%\:\*\=\+\-\—ёЁ\/ ]", '', $string);
+	public static function rucharclean($string, $trim = 0) {
+	    if($trim != 0) return mb_substr(mb_ereg_replace("/[^A-Za-zА-Яа-я0-9\[\]\!\.\?\(\)\,\@\#\%\:\*\=\+\-\—ёЁ\/ ]/", '', $string), 0, $trim);
+	    else return mb_ereg_replace("/[^A-Za-zА-Яа-я0-9\[\]\!\.\?\(\)\,\@\#\%\:\*\=\+\-\—ёЁ\/ ]/", '', $string);
 	}
 	public static function numbercolon($string, $trim = 0){
 		if($trim != 0) return mb_substr(preg_replace("/[^0-9,-]/", '', $string), 0, $trim);


### PR DESCRIPTION
A very small but important change to the **rucharclean()** in `exploitPatch.php` that breaks the **preg_replace()**

That fix:

- dashboard/api/addSong.php
- dashboard/api/searchLevel.php
- dashboard/profile/replies.php
- dashboard/songs/index.php when you search

