### PR TITLE
Fix leaderboard mod badge in comments

### DIFF
--- a/incl/comments/getGJComments.php
+++ b/incl/comments/getGJComments.php
@@ -75,6 +75,7 @@ foreach($result as &$comment1) {
 			$comment1['userName'] = $gs->makeClanUsername($comment1);
 			if($binaryVersion > 31){
 				$badge = $gs->getMaxValuePermission($extID, "modBadgeLevel");
+				$badge = $badge > 2 ? '' : $badge;
 				$colorString = $badge > 0 ? "~12~".$gs->getAccountCommentColor($extID) : "";
 				$commentstring .= "~11~${badge}${colorString}:1~".$comment1["userName"]."~7~1~9~".$comment1["icon"]."~10~".$comment1["color1"]."~11~".$comment1["color2"]."~14~".$comment1["iconType"]."~15~".$comment1["special"]."~16~".$comment1["extID"];
 			}elseif(!in_array($comment1["userID"], $users)){


### PR DESCRIPTION
There is a blue badge (3) for 'leaderboard moderators' and this badge cannot be displayed in level comments. When you have a role with modLevelBadge = 3, it shows the blue badge in their profile but in comments they have a default yellow mod badge (1)

This PR fixes this and shows no badge in comments for people with blue mod badge.