### PR TITLE
Add new setting for daily/weekly levels

### DIFF
--- a/config/misc.php
+++ b/config/misc.php
@@ -8,6 +8,21 @@ $maxCommentLength = 100; // default = 100, 100 characters is the default length 
 $maxAccountCommentLength = 140; // default = 140, 140 characters is the default length for account comments in game
 
 /*
+	Daily/Weekly logic
+	
+	This setting refers to the situation where you did not set the new daily/weekly level.
+	
+	Usually, daily levels can be played for 1 day and weekly levels can be played for 1 week.
+	After that these levels should 'expire' and no one can play them again (in daily/weekly tab)
+	
+	True - When the daily/weekly level expires, still show it for players, until the new level is set. (default)
+	False - When the daily/weekly level expires, show no level and a timer, until the new level is set.
+	
+	Note: if you select "true" and daily level is not updated, it still can be beaten only once, then the player will see only a timer.
+*/
+$oldDailyWeekly = true;
+
+/*
     Minimum and Maximum Game versions
 
     Set both to 0 to disable

--- a/config/misc.php
+++ b/config/misc.php
@@ -1,11 +1,40 @@
 <?php
-$orderMapPacksByStars = true; // true = in-game, order map packs by difficulty, false = in-game, order map packs by the date when they were created (newest to oldest)
+/*
+	Map-packs order in-game
+	
+	True - Order map-packs by their diffuculty
+	False - Order map-packs by their creation date (newest to oldest)
+*/
 
-$sakujes = true; // true = rename everyone to sakujes in the leaderboard on april 1st, false = don't rename everyone to sakujes in the leaderboard on april 1st
+$orderMapPacksByStars = true;
 
-$enableCommentLengthLimiter = true; // true = use the 2 settings below to limit the amount of characters a comment can have, false = don't use the 2 settings below and unrestrict comment lengths
-$maxCommentLength = 100; // default = 100, 100 characters is the default length for comments in game
-$maxAccountCommentLength = 140; // default = 140, 140 characters is the default length for account comments in game
+/*
+	SAKUJES
+	
+	This is April Fools joke by Cvolton, when leaderboards would fill with SAKUJES players and have 999 stats
+	
+	True - Enable this joke
+	False - Keep leaderboards normal on April Fools
+*/
+
+$sakujes = true;
+
+/*
+	Comment length limiter
+	
+	This setting will enable comment length limiter to prevent flooding with scripts
+	
+	$enableCommentLengthLimiter:
+		True - Use $maxCommentLength and $maxAccountCommentLength to limit comment length
+		False - Don't limit comments by their length
+	
+	$maxCommentLength - Maximum level comment length, default is 100
+	$maxAccountCommentLength - Maximum profile comment length, default is 140
+*/
+
+$enableCommentLengthLimiter = true;
+$maxCommentLength = 100;
+$maxAccountCommentLength = 140;
 
 /*
 	Daily/Weekly logic
@@ -20,7 +49,8 @@ $maxAccountCommentLength = 140; // default = 140, 140 characters is the default 
 	
 	Note: if you select "true" and daily level is not updated, it still can be beaten only once, then the player will see only a timer.
 */
-$oldDailyWeekly = true;
+
+$oldDailyWeekly = false;
 
 /*
     Minimum and Maximum Game versions
@@ -33,6 +63,7 @@ $oldDailyWeekly = true;
 
     Note: setting both to the same value will only allow this specific version
 */
+
 $minGameVersion = 0;
 $maxGameVersion = 0;
 
@@ -44,27 +75,65 @@ $maxGameVersion = 0;
     2.202 = 38
     2.201 = 37
     2.200 = 36
-
     ...
 */
+
 $minBinaryVersion = 0;
 $maxBinaryVersion = 0;
 
-$showAllLevels = false; // true => Shows all levels like robtop, even if the client can't support it || false => Only shows levels supported by client
+/*
+	Show levels from newer GD version
+	
+	This setting will allow showing levels if they were posted from newer GD version, than yours
+	
+	True - Show all levels
+	False - Only show levels your GD version support
+*/
 
-$leaderboardMinStars = 0; // Minimum amount of stars for players to be displayed in the leaderboard, GD default is 500
+$showAllLevels = false;
 
-$ratedLevelsUpdates = true; // true => allow updates on rated levels || false => dont allow rated levels to be updated, you can put exceptions as IDs in the parameter below
+/*
+	Amount of stars for leaderboards
+
+	$leaderboardMinStars - Minimum amount of stars for players to be displayed in the leaderboard, default is 10
+*/
+
+$leaderboardMinStars = 10;
+
+/*
+	Update rated levels
+	
+	This setting allows to disable updating of rated levels
+	
+	$ratedLevelsUpdates:
+		True - Allow updating rated levels
+		False - Disllow updating rated levels
+		
+	$ratedLevelsUpdatesExceptions - Levels exceptions, works if you set $ratedLevelsUpdates to true
+*/
+
+$ratedLevelsUpdates = true;
 $ratedLevelsUpdatesExceptions = [
-    1, // example
-    2 // example
+    1,
+    2
 ];
 
-// New configurations for comment auto-like feature
-$commentAutoLike = false; // true = auto-like is enabled, false = auto-like is disabled
+/*
+	Multiply comment likes by value
+	
+	This is fun setting, it will allow you to visually multiply comment likes by value you set
+	
+	$commentAutoLike:
+		True - Enable multiplying
+		False - Disable multiplying
+		
+	$specialCommentLikes - Comment IDs and their multipliers:
+		Comment ID => Multiplier
+*/
+
+$commentAutoLike = false;
 $specialCommentLikes = [
-    1 => 10, // commentID => multiplier
-    2 => 20, // another commentID => multiplier
-    // Add more comment IDs and their multipliers as needed
+    1 => 10,
+    2 => 20
 ];
 ?>

--- a/incl/levels/getGJDailyLevel.php
+++ b/incl/levels/getGJDailyLevel.php
@@ -2,6 +2,7 @@
 chdir(dirname(__FILE__));
 include "../lib/connection.php";
 include "../lib/mainLib.php";
+include "../../config/misc.php";
 $gs = new mainLib();
 $type = !empty($_POST["type"]) ? $_POST["type"] : (!empty($_POST["weekly"]) ? $_POST["weekly"] : 0);
 $midnight = ($type == 1) ? strtotime("next monday") : strtotime("tomorrow 00:00:00");
@@ -14,9 +15,8 @@ $dailyID = $daily['feaID'];
 if($type == 1) $dailyID += 100001;
 $timeleft = $midnight - $current;
 
-if(!$oldDailyWeekly){
+if(!$oldDailyWeekly) {
 	$expire = $daily['timestamp'] + ($type == 0 ? 86400 : 604800);
-	
 	if($expire < $current) exit('0|'.$timeleft);
 }
 

--- a/incl/levels/getGJDailyLevel.php
+++ b/incl/levels/getGJDailyLevel.php
@@ -13,6 +13,13 @@ if($query->rowCount() == 0) exit("-1");
 $dailyID = $daily['feaID'];
 if($type == 1) $dailyID += 100001;
 $timeleft = $midnight - $current;
+
+if(!$oldDailyWeekly){
+	$expire = $daily['timestamp'] + ($type == 0 ? 86400 : 604800);
+	
+	if($expire < $current) exit('0|'.$timeleft);
+}
+
 if(!$daily['webhookSent']) {
 	$gs->sendDailyWebhook($daily['levelID'], $daily['type']);
 	$sent = $db->prepare('UPDATE dailyfeatures SET webhookSent = 1 WHERE feaID = :feaID');


### PR DESCRIPTION
Now you can disable displaying old daily/weekly levels when the new ones are not set by admins

Fixes #169 