### PR TITLE
Fix the "featured" filter in the advanced options

### DIFF
--- a/incl/levels/getGJLevels.php
+++ b/incl/levels/getGJLevels.php
@@ -99,7 +99,7 @@ if(!empty($_POST["len"])){
 if($len != "-" AND !empty($len)){
 	$params[] = "levelLength IN ($len)";
 }
-if(!empty($_POST["featured"])) $epicParams[] = "starFeatured = 1";
+if(!empty($_POST["featured"])) $epicParams[] = "starFeatured > 0";
 if(!empty($_POST["epic"])) $epicParams[] = "starEpic = 1";
 if(!empty($_POST["mythic"])) $epicParams[] = "starEpic = 2";
 if(!empty($_POST["legendary"])) $epicParams[] = "starEpic = 3";


### PR DESCRIPTION
Necessary enhancement that should have been done some time ago. With the featured score the `starFeatured` column no longer remains = to 1 but > than 0.