### PR TITLE
Added default avatar to user accounts list in Dashboard

### DIFF
--- a/dashboard/account/changeUsername.php
+++ b/dashboard/account/changeUsername.php
@@ -67,6 +67,8 @@ if($pass == 1) {
 	$auth = $gs->randomString(8);
 	$query = $db->prepare("UPDATE accounts SET userName=:userName, salt=:salt, auth=:auth WHERE accountID=:accountid");	
 	$query->execute([':userName' => $newnick, ':salt' => $salt, ':accountid' => $accID, ':auth' => $auth]);
+	$query = $db->prepare("UPDATE levels SET userName=:newnick WHERE userName=:oldnick");
+	$query->execute([':newnick' => $newnick, ':oldnick' => $oldnick]); // IMPORTANT: each level's username will change along with the account username
 	$query = $db->prepare("UPDATE users SET userName=:userName WHERE extID=:accountid");
 	$query->execute([':userName' => $newnick,':accountid' => $accID]);
 	$_SESSION["accountID"] = 0;

--- a/dashboard/account/forceChange.php
+++ b/dashboard/account/forceChange.php
@@ -60,6 +60,8 @@ if(!empty($_POST["userID"]) AND !empty($_POST[$type])) {
 	}
 	$query = $db->prepare("UPDATE accounts SET userName=:userName, salt=:salt WHERE accountID=:accountid");	
 	$query->execute([':userName' => $newnick, ':salt' => $salt, ':accountid' => $accID]);
+	$query = $db->prepare("UPDATE levels SET userName=:userName WHERE userName=:oldUserName");
+    $query->execute([':userName' => $newnick, ':oldUserName' => $gs->getUserName($accID)]); // IMPORTANT: each level's username will change along with the account username
 	$query = $db->prepare("UPDATE users SET userName=:userName WHERE extID=:accountid");
 	$query->execute([':userName' => $newnick,':accountid' => $accID]);
     $auth = $gs->randomString(8);

--- a/dashboard/clan/index.php
+++ b/dashboard/clan/index.php
@@ -326,16 +326,36 @@ if(!empty($clan)) {
 		$allcp += $mbr['creatorPoints'];
         $stats = $dl->createProfileStats($mbr['stars'], $mbr['moons'], $mbr['diamonds'], $mbr['coins'], $mbr['userCoins'], $mbr['demons'], $mbr['creatorPoints'], 0);
 		$mbr["userName"] = $mbr["userName"] == 'Undefined' ? $gs->getAccountName($mbr['extID']) : $mbr['userName'];
-        if($mbr["extID"] != $clan["clanOwner"]) $members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
-			<div class="profile"><div class="clanmemberndiv"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$mbr["userName"].'\', true, true, \'GET\')"><h2 style="color:rgb('.$gs->getAccountCommentColor($mbr["extID"]).')" class="profilenick clanmembernick">'.$mbr["userName"].'</h2></button>'.$kick.'</div>
-			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
-			<h3 id="comments" style="justify-content: flex-end;grid-gap: 0.5vh;">'.sprintf($dl->getLocalizedString("joinedAt"), $dl->convertToDate($mbr["joinedAt"], true)).'</h3>
-		</div></div>';
-		else $owner = '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
-			<div class="profile"><div style="display:flex"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$mbr['userName'].'\', true, true, \'GET\')"><h1 style="margin: 0;margin-bottom: 10px;color:rgb('.$gs->getAccountCommentColor($mbr["extID"]).')" class="profilenick clanownernick">'.$mbr["userName"].' <i style="color:#ffff91" class="fa-solid fa-crown"></i></h1></button></div>
-			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
-			<h3 class="comments clancreatetext">'.sprintf($dl->getLocalizedString("createdAt"), $dl->convertToDate($clan["creationDate"], true)).'</h3>
-		</div></div>';
+		// Avatar management
+		$avatarImg = '';
+		$iconType = ($mbr['iconType'] > 8) ? 0 : $mbr['iconType'];
+		$iconTypeMap = [0 => ['type' => 'cube', 'value' => $mbr['accIcon']], 1 => ['type' => 'ship', 'value' => $mbr['accShip']], 2 => ['type' => 'ball', 'value' => $mbr['accBall']], 3 => ['type' => 'ufo', 'value' => $mbr['accBird']], 4 => ['type' => 'wave', 'value' => $mbr['accDart']], 5 => ['type' => 'robot', 'value' => $mbr['accRobot']], 6 => ['type' => 'spider', 'value' => $mbr['accSpider']], 7 => ['type' => 'swing', 'value' => $mbr['accSwing']], 8 => ['type' => 'jetpack', 'value' => $mbr['accJetpack']]];
+		$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        if($mbr["extID"] != $clan["clanOwner"]) {
+			$badgeImg = '';
+			$queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
+			$queryRoleID->execute([':accountID' => $mbr["extID"]]);	
+			if($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+				$queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+				$queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
+				if(($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+					$badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: -3px; margin-top: -3px; vertical-align: middle;">';
+				}
+			}	
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $mbr['color1'] . '&color2=' . $mbr['color2'] . ($mbr['accGlow'] != 0 ? '&glow=' . $mbr['accGlow'] . '&color3=' . $mbr['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+			$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
+				<div class="profile"><div class="clanmemberndiv"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$mbr["userName"].'\', true, true, \'GET\')"><h2 style="color:rgb('.$gs->getAccountCommentColor($mbr["extID"]).')" class="profilenick clanmembernick"><div class="accounts-badge-icon-div">'.$avatarImg.$mbr["userName"].$badgeImg.'</div></h2></button>'.$kick.'</div>
+				<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
+				<h3 id="comments" style="justify-content: flex-end;grid-gap: 0.5vh;">'.sprintf($dl->getLocalizedString("joinedAt"), $dl->convertToDate($mbr["joinedAt"], true)).'</h3>
+			</div></div>';
+		} else {
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $mbr['color1'] . '&color2=' . $mbr['color2'] . ($mbr['accGlow'] != 0 ? '&glow=' . $mbr['accGlow'] . '&color3=' . $mbr['color3'] : '') . '" alt="Avatar" style="width: 40px; height: 40px; vertical-align: middle; object-fit: contain;">';
+			$owner = '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
+				<div class="profile"><div style="display:flex"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$mbr['userName'].'\', true, true, \'GET\')"><h1 style="margin: 0; margin-bottom: 10px; color: rgb('.$gs->getAccountCommentColor($mbr["extID"]).'); justify-content: center; grid-gap: 10px;" class="profilenick clanownernick accounts-badge-icon-div">'.$avatarImg.$mbr["userName"].'<i style="color:#ffff91" class="fa-solid fa-crown"></i></h1></button></div>
+				<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
+				<h3 class="comments clancreatetext">'.sprintf($dl->getLocalizedString("createdAt"), $dl->convertToDate($clan["creationDate"], true)).'</h3>
+			</div></div>';
+		}
     }
 	$allstats = $dl->createProfileStats($allstars, $allmoons, $alldias, $allcoins, $allucoins, $alldemons, $allcp, 0);
 	$total = '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;margin-top:10px">

--- a/dashboard/clans/index.php
+++ b/dashboard/clans/index.php
@@ -34,8 +34,19 @@ foreach($clans as &$clan) {
     if($dontmind == 1) $dm = 0; elseif($dontmind < 5 AND $dontmind > 0) $dm = 1; else $dm = 2;
     if($members > 9 AND $members < 20) $dm = 2;
 	if($clan["isClosed"] == 1) $closed = ' <i style="font-size:15px;color:#36393e" class="fa-solid fa-lock"></i>';
+	// Avatar management
+	$avatarImg = '';
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $clan["clanOwner"]]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$options .= '<div class="profile clanscard"><div style="margin-right: 10px;width: 100%">
-		<div class="clansname"><h1>'.sprintf($dl->getLocalizedString('demonlistLevel'), '<span style="color:#'.$clan["color"].';grid-gap: 3px;display: inline-flex;"> ['.$tag.'] '.$name.$closed.'</span>', $clan["clanOwner"], $gs->getAccountName($clan["clanOwner"])).'</h1>
+		<div class="clansname"><h1>'.sprintf($dl->getLocalizedString('demonlistLevel'), '<span style="color:#'.$clan["color"].';grid-gap: 3px;display: inline-flex;"> ['.$tag.'] '.$name.$closed.'</span>', $clan["clanOwner"], $gs->getAccountName($clan["clanOwner"]), $avatarImg).'</h1>
 		<div class="clansmembercount"><h3 style="margin: 0;font-size: 20px;">'.sprintf($dl->getLocalizedString("members".$dm), $members).'</h3><button style="width:max-content;padding:15px;height:max-content" type="button" onclick="a(\'clan/'.$name.'\', true, true)" class="btn-rendel"><i class="fa-solid fa-magnifying-glass"></i></button></div></div>
 		<p class="clansdesc">'.$desc.'</p></div>
 	</div>';

--- a/dashboard/incl/cvolton.css
+++ b/dashboard/incl/cvolton.css
@@ -2178,3 +2178,9 @@ body:has(.audio) {
 .modactionsspoiler {
 	font-size: 25px;
 }
+
+.accounts-badge-icon-div {
+	display: flex;
+    align-items: center;
+    grid-gap: 5px;
+}

--- a/dashboard/incl/lang/localeCZ.php
+++ b/dashboard/incl/lang/localeCZ.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'nikdo neporazil'; //let it be lowercase
 $string["oneBeat"] = '1 hráč porazil'; 
 $string["lower5Beat"] = '%d hráči porazili'; // russian syntax, sorry
 $string["above5Beat"] = '%d hráčů porazilo'; 
-$string["demonlistLevel"] = '%s <text class="dltext">od <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">od <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Vypadá to, že váš demonlist nemá žádné démony...';
 $string["addSomeDemons"] = 'Přidejte démony pro vyplnění demonlistu!';
 $string["askForDemons"] = 'Zeptejte se administrátora serveru pro přidání některých!';

--- a/dashboard/incl/lang/localeEN.php
+++ b/dashboard/incl/lang/localeEN.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'noone has beaten'; //let it be lowercase
 $string["oneBeat"] = '1 player has beaten'; 
 $string["lower5Beat"] = '%d players have beaten'; // russian syntax, sorry
 $string["above5Beat"] = '%d players have beaten'; 
-$string["demonlistLevel"] = '%s <text class="dltext">by <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">by <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'It seems that your demonlist doesn\'t have any demons...';
 $string["addSomeDemons"] = 'Add some demons to fill up demonlist!';
 $string["askForDemons"] = 'Ask server\'s administrator to add some!';

--- a/dashboard/incl/lang/localeES.php
+++ b/dashboard/incl/lang/localeES.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'nadie lo ha completado'; //let it be lowercase
 $string["oneBeat"] = '1 jugador lo ha completado'; 
 $string["lower5Beat"] = '%d jugadores lo han completado'; // russian syntax, sorry
 $string["above5Beat"] = '%d jugadores lo han completado'; 
-$string["demonlistLevel"] = '%s <text class="dltext">por <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">por <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Parece que la demonlist está vacía...';
 $string["addSomeDemons"] = 'Agrega demons para llenar la demonlist';
 $string["askForDemons"] = 'Solicita a un Moderador que agregue demons';

--- a/dashboard/incl/lang/localeFR.php
+++ b/dashboard/incl/lang/localeFR.php
@@ -289,7 +289,7 @@ $string["nooneBeat"] = 'personne ne l\'a battu'; //let it be lowercase
 $string["oneBeat"] = '1 joueur l\'a battu'; 
 $string["lower5Beat"] = '%d joueurs l\'ont battu'; // russian syntax, sorry
 $string["above5Beat"] = '%d joueurs l\'ont battu'; 
-$string["demonlistLevel"] = '%s <text class="dltext"> par <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext"> par <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'On dirait que votre demonlist n\'a aucun démon...';
 $string["addSomeDemons"] = 'Ajoutez quelques démons pour remplir votre demonlist !';
 $string["askForDemons"] = 'Demandez à l\'administrateur du serveur\'s qu\'il en ajoute !';

--- a/dashboard/incl/lang/localeIT.php
+++ b/dashboard/incl/lang/localeIT.php
@@ -62,7 +62,7 @@ $string["changeUsername"] = "Cambia nome utente";
 $string["unlistedLevels"] = "I tuoi livelli non elencati";
 
 $string["manageSongs"] = "Gestisci i brani";
-$string["gauntletManage"] = "Gestisci i guanti";
+$string["gauntletManage"] = "Gestisci i gauntlets";
 $string["suggestLevels"] = "Livelli suggeriti";
 
 $string["modTools"] = "Strumenti di moderazione";
@@ -575,12 +575,12 @@ $string["modAction13"] = "Descrizione del livello modificata";
 $string["modAction14"] = "LDM abilitato/disabilitato";
 $string["modAction15"] = "Classifica non/vietata";
 $string["modAction16"] = "Modifica dell'ID del brano";
-$string["modAction17"] = "Creato un pacchetto mappe";
-$string["modAction18"] = "Creato un guanto di sfida";
+$string["modAction17"] = "Creato un map pack";
+$string["modAction18"] = "Creato un gauntlet";
 $string["modAction19"] = "Brano cambiato";
 $string["modAction20"] = "Concesso un moderatore al giocatore";
-$string["modAction21"] = "Pacchetto mappe modificato";
-$string["modAction22"] = "Guanto modificato";
+$string["modAction21"] = "Map pack modificato";
+$string["modAction22"] = "Gauntlet modificato";
 $string["modAction23"] = "Missione modificata";
 $string["modAction24"] = "Riassegnato un giocatore";
 $string["modAction25"] = "Creata una missione";

--- a/dashboard/incl/lang/localeIT.php
+++ b/dashboard/incl/lang/localeIT.php
@@ -289,7 +289,7 @@ $string["nooneBeat"] = 'nessuno ha battuto'; //let it be lowercase
 $string["oneBeat"] = '1 giocatore ha battuto'; 
 $string["lower5Beat"] = '%d giocatori hanno battuto'; // russian syntax, sorry
 $string["above5Beat"] = '%d giocatori hanno battuto'; 
-$string["demonlistLevel"] = '%s <text class="dltext">di <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">di <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Sembra che la tua lista dei demon non abbia demon...';
 $string["addSomeDemons"] = 'Aggiungi alcuni demon per riempire la lista dei demon!';
 $string["askForDemons"] = 'Chiedi all\'amministratore del server di aggiungerne alcuni!';

--- a/dashboard/incl/lang/localePL.php
+++ b/dashboard/incl/lang/localePL.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'nikt nie przeszedł'; //let it be lowercase
 $string["oneBeat"] = '1 gracz przeszedł'; 
 $string["lower5Beat"] = '%d graczy przeszło'; // russian syntax, sorry
 $string["above5Beat"] = '%d graczy przeszło'; 
-$string["demonlistLevel"] = '%s <text class="dltext">przez <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">przez <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Wygląda na to, że demonlista nie ma żadnych demonów...';
 $string["addSomeDemons"] = 'Dodaj trochę demonów żeby zapełnić demonlistę!';
 $string["askForDemons"] = 'Zapytaj administratora serwera aby trochę dodać!';

--- a/dashboard/incl/lang/localePT.php
+++ b/dashboard/incl/lang/localePT.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'ninguém completou'; //let it be lowercase
 $string["oneBeat"] = '1 jogador completou';
 $string["lower5Beat"] = '%d jogadores completaram'; // russian syntax, sorry
 $string["above5Beat"] = '%d jogadores completaram';
-$string["demonlistLevel"] = '%s <text class="dltext">por <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">por <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Parece que sua lista de demônios não tem nenhum demônio...';
 $string["addSomeDemons"] = 'Adicione alguns demônios para preencher a lista de demônios!';
 $string["askForDemons"] = 'Peça ao administrador do servidor para adicionar alguns!';

--- a/dashboard/incl/lang/localeRU.php
+++ b/dashboard/incl/lang/localeRU.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'никто не прошёл'; //let it be lowercase
 $string["oneBeat"] = 'прошёл 1 игрок'; 
 $string["lower5Beat"] = 'прошло %d игрока'; 
 $string["above5Beat"] = 'прошло %d игроков'; 
-$string["demonlistLevel"] = '%s <text class="dltext">от <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">от <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Кажется, в вашем топе демонов нет ни одного демона...';
 $string["addSomeDemons"] = 'Добавьте несколько демонов, чтобы заполнить топ!';
 $string["askForDemons"] = 'Попросите администратора сервера добавить несколько!';

--- a/dashboard/incl/lang/localeTR.php
+++ b/dashboard/incl/lang/localeTR.php
@@ -287,7 +287,7 @@ $string["nooneBeat"] = 'kimse geçemedi'; //let it be lowercase
 $string["oneBeat"] = '1 oyuncu geçti'; 
 $string["lower5Beat"] = '%d oyuncu geçti'; // russian syntax, sorry
 $string["above5Beat"] = '%d oyuncu geçti'; 
-$string["demonlistLevel"] = '%s<text class="dltext"><button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button> tarafından</text>';
+$string["demonlistLevel"] = '%s<text class="dltext"><button type="button" onclick="a(\'profile/%3$s\', true, true)" style="margin-left: 5px; font-size: 25px" class="accbtn" name="accountID" value="%d">%s %4$s</button> tarafından</text>';
 $string["noDemons"] = 'Görünüşe göre demon listesi demon seviyesi bölüm içermiyor...';
 $string["addSomeDemons"] = 'Listeyi doldurmak için demon seviyesi bölüm ekle!';
 $string["askForDemons"] = 'Bir yöneticiden bu listeye eklemesini iste!';

--- a/dashboard/incl/lang/localeUA.php
+++ b/dashboard/incl/lang/localeUA.php
@@ -288,7 +288,7 @@ $string["nooneBeat"] = 'ніхто не пройшов'; //let it be lowercase
 $string["oneBeat"] = 'пройшов 1 ігрок'; 
 $string["lower5Beat"] = 'пройшло %d ігрока'; 
 $string["above5Beat"] = 'пройшло %d ігроків'; 
-$string["demonlistLevel"] = '%s <text class="dltext">від <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button></text>';
+$string["demonlistLevel"] = '%s <text class="dltext">від <button type="button" onclick="a(\'profile/%3$s\', true, true)" style="font-size:25px" class="accbtn" name="accountID" value="%d">%s</button>%4$s</text>';
 $string["noDemons"] = 'Здається, у вашому топі демонів немає ні одного демону...';
 $string["addSomeDemons"] = 'Додайте декілька демонів, щоб заповнити топ!';
 $string["askForDemons"] = 'Попросіть адміністратора серверу додати декілька!';

--- a/dashboard/profile/index.php
+++ b/dashboard/profile/index.php
@@ -228,7 +228,17 @@ if(isset($_POST["settings"]) AND $_POST["settings"] == 1 AND $accid == $_SESSION
 $query = $db->prepare("SELECT * FROM users WHERE userID=:id");
 $query->execute([':id' => $userID]);
 $res = $query->fetch();
-$maybeban = '<h1 class="profilename" style="color:rgb('.$gs->getAccountCommentColor($accid).');">'.$accname.'</h1>';
+$badgeImg = '';
+$queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
+$queryRoleID->execute([':accountID' => $accid]);	
+if($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+    $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+    $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
+    if(($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+        $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-top: -3px; vertical-align: middle;">';
+    }
+}
+$maybeban = '<h1 class="profilename" style="color:rgb('.$gs->getAccountCommentColor($accid).');">'.$accname.$badgeImg.'</h1>';
 if(isset($_SERVER["HTTP_REFERER"])) $back = '<form method="post" action="'.$_SERVER["HTTP_REFERER"].'"><button type="button" onclick="a(\''.$_SERVER["HTTP_REFERER"].'\', true, true, \'GET\')" class="goback"><i class="fa-solid fa-arrow-left" aria-hidden="true"></i></button></form>'; else $back = '';
 $all = $dl->createProfileStats($res['stars'], $res['moons'], $res['diamonds'], $res['coins'], $res['userCoins'], $res['demons'], $res['creatorPoints'], 0);
 $msgs = $db->prepare("SELECT * FROM acccomments WHERE userID=:uid ORDER BY commentID DESC");

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -83,16 +83,16 @@ foreach($result as &$action) {
     $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
     $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
     $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; object-fit: contain;">';
     // Badge management
     $badgeImg = '';
     $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
     $queryRoleID->execute([':accountID' => $accountID]);	
-    if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+    if($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
         $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
         $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
-        if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
-            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
+        if(($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: -3px; margin-top: -3px; vertical-align: middle;">';
         }
     }		
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0);
@@ -100,7 +100,7 @@ foreach($result as &$action) {
 	if($action['userName'] == "Undefined") $action['userName'] = $gs->getAccountName($action["accountID"]);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick"><div class="accounts-badge-icon-div">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.'</div> '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -82,13 +82,35 @@ foreach($result as &$action) {
         $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
         $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
         $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=1&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 34px; margin-right: 10px; object-fit: contain;">';
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=1&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+
+    // Badge management
+    $badgeImg = '';
+    $accountID = $action['extID']; // Get the accountID from the action
+    
+    // Finds the roleID associated with the accountID from the roleassign table
+    $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
+    $queryRoleID->execute([':accountID' => $accountID]);
+    $roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC);
+    if ($roleAssignData) {
+        $roleID = $roleAssignData['roleID'];
+        
+        // Finds the modBadgeLevel associated with the roleID from the roles table
+        $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+        $queryBadgeLevel->execute([':roleID' => $roleID]);
+        $roleData = $queryBadgeLevel->fetch(PDO::FETCH_ASSOC);
+        $modBadgeLevel = $roleData['modBadgeLevel'] ?? 0;
+        if ($modBadgeLevel >= 1 && $modBadgeLevel <= 3) {
+            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
+        }
+    }	
+	
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0);
 	$registerDate = date("d.m.Y", $action["registerDate"]);
 	if($action['userName'] == "Undefined") $action['userName'] = $gs->getAccountName($action["accountID"]);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -79,56 +79,16 @@ foreach($result as &$action) {
 		if($claninfo["clanOwner"] == $action["accountID"]) $own = '<i style="color:#ffff91" class="fa-solid fa-crown"></i>';
 		$clan = '<span style="display:contents;cursor:pointer"><h2 class="music" style="width: max-content;margin-left: 5px;grid-gap:5px;color:#'.$claninfo["color"].'">'.$claninfo["clan"].$own.'</h2></span>';
 	}
-    $iconType = $action['iconType'];
-    $iconValue = '';
-    $iconTypeMap = [
-        0 => 'accIcon',
-        1 => 'accShip',
-        2 => 'accBall',
-        3 => 'accBird',
-        4 => 'accDart',
-        5 => 'accRobot',
-        6 => 'accSpider',
-        7 => 'accSwing',
-        8 => 'accJetpack'
-    ];
-
-    // Set the icon value based on the type
-    if (isset($iconTypeMap[$iconType])) {
-        $iconValue = $action[$iconTypeMap[$iconType]];
-        if ($iconValue == 0) {
-            $iconValue = 1;
-        }
-    }
-
-    // Icon URL construction
-    $iconTypeName = array(
-        0 => "cube",
-        1 => "ship",
-        2 => "ball",
-        3 => "ufo",
-        4 => "wave",
-        5 => "robot",
-        6 => "spider",
-        7 => "swing",
-        8 => "jetpack"
-    )[$iconType];
-    
-    $iconUrl = "https://gdicon.oat.zone/icon.png?type=$iconTypeName&value=$iconValue&color1=".$action['color1']."&color2=".$action['color2'];
-
-    if ($action['accGlow'] != 0) {
-        $iconUrl .= "&glow=1&color3=".$action['color3'];
-    }
-
-    // Adding the avatar next to the username
-    $avatarImg = '<img src="'.$iconUrl.'" alt="avatar" style="width:30px; height:30px; margin-left:5px; vertical-align:middle;">';
-		
+        $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
+        $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=1&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 34px; margin-right: 10px; object-fit: contain;">';
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0);
 	$registerDate = date("d.m.Y", $action["registerDate"]);
 	if($action['userName'] == "Undefined") $action['userName'] = $gs->getAccountName($action["accountID"]);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$action["userName"].' '.$avatarImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -55,7 +55,7 @@ if(!isset($_GET["search"]) OR empty(trim(ExploitPatch::remove($_GET["search"])))
 	} 
 }
 $x = $page + 1;
-foreach($result as &$action){
+foreach($result as &$action) {
 	$clan = $own = '';
 	$accUserID = $action["userID"];
 	$accountID = $action["accountID"].' <text style="font-weight: 100;">|</text> '.$accUserID;
@@ -79,12 +79,56 @@ foreach($result as &$action){
 		if($claninfo["clanOwner"] == $action["accountID"]) $own = '<i style="color:#ffff91" class="fa-solid fa-crown"></i>';
 		$clan = '<span style="display:contents;cursor:pointer"><h2 class="music" style="width: max-content;margin-left: 5px;grid-gap:5px;color:#'.$claninfo["color"].'">'.$claninfo["clan"].$own.'</h2></span>';
 	}
+    $iconType = $action['iconType'];
+    $iconValue = '';
+    $iconTypeMap = [
+        0 => 'accIcon',
+        1 => 'accShip',
+        2 => 'accBall',
+        3 => 'accBird',
+        4 => 'accDart',
+        5 => 'accRobot',
+        6 => 'accSpider',
+        7 => 'accSwing',
+        8 => 'accJetpack'
+    ];
+
+    // Set the icon value based on the type
+    if (isset($iconTypeMap[$iconType])) {
+        $iconValue = $action[$iconTypeMap[$iconType]];
+        if ($iconValue == 0) {
+            $iconValue = 1;
+        }
+    }
+
+    // Icon URL construction
+    $iconTypeName = array(
+        0 => "cube",
+        1 => "ship",
+        2 => "ball",
+        3 => "ufo",
+        4 => "wave",
+        5 => "robot",
+        6 => "spider",
+        7 => "swing",
+        8 => "jetpack"
+    )[$iconType];
+    
+    $iconUrl = "https://gdicon.oat.zone/icon.png?type=$iconTypeName&value=$iconValue&color1=".$action['color1']."&color2=".$action['color2'];
+
+    if ($action['accGlow'] != 0) {
+        $iconUrl .= "&glow=1&color3=".$action['color3'];
+    }
+
+    // Adding the avatar next to the username
+    $avatarImg = '<img src="'.$iconUrl.'" alt="avatar" style="width:30px; height:30px; margin-left:5px; vertical-align:middle;">';
+		
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0);
 	$registerDate = date("d.m.Y", $action["registerDate"]);
 	if($action['userName'] == "Undefined") $action['userName'] = $gs->getAccountName($action["accountID"]);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$action["userName"].' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$action["userName"].' '.$avatarImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -79,11 +79,11 @@ foreach($result as &$action) {
 		if($claninfo["clanOwner"] == $action["accountID"]) $own = '<i style="color:#ffff91" class="fa-solid fa-crown"></i>';
 		$clan = '<span style="display:contents;cursor:pointer"><h2 class="music" style="width: max-content;margin-left: 5px;grid-gap:5px;color:#'.$claninfo["color"].'">'.$claninfo["clan"].$own.'</h2></span>';
 	}
-        $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
-        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
-        $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
-
+	// Avatar management
+    $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
+    $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
+    $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
     // Badge management
     $badgeImg = '';
     $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
@@ -94,8 +94,7 @@ foreach($result as &$action) {
         if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
             $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
         }
-    }	
-	
+    }		
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0);
 	$registerDate = date("d.m.Y", $action["registerDate"]);
 	if($action['userName'] == "Undefined") $action['userName'] = $gs->getAccountName($action["accountID"]);

--- a/dashboard/stats/accountsList.php
+++ b/dashboard/stats/accountsList.php
@@ -82,25 +82,16 @@ foreach($result as &$action) {
         $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
         $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
         $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=1&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
 
     // Badge management
     $badgeImg = '';
-    $accountID = $action['extID']; // Get the accountID from the action
-    
-    // Finds the roleID associated with the accountID from the roleassign table
     $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
-    $queryRoleID->execute([':accountID' => $accountID]);
-    $roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC);
-    if ($roleAssignData) {
-        $roleID = $roleAssignData['roleID'];
-        
-        // Finds the modBadgeLevel associated with the roleID from the roles table
+    $queryRoleID->execute([':accountID' => $accountID]);	
+    if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
         $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
-        $queryBadgeLevel->execute([':roleID' => $roleID]);
-        $roleData = $queryBadgeLevel->fetch(PDO::FETCH_ASSOC);
-        $modBadgeLevel = $roleData['modBadgeLevel'] ?? 0;
-        if ($modBadgeLevel >= 1 && $modBadgeLevel <= 3) {
+        $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
+        if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
             $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
         }
     }	

--- a/dashboard/stats/dailyTable.php
+++ b/dashboard/stats/dailyTable.php
@@ -78,54 +78,28 @@ foreach($result as &$daily){
 		$dt = '<p class="profilepic"><i class="fa-regular fa-clock"></i> '.$dtt.'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$level['downloads'].'</p>';
 		$all = $dailyl.$dt.$dls.$stats.$st.$ln.$lp.$rs;
-        // Avatar management
+		// Avatar management
 	    $avatarImg = '';
         $query = $db->prepare('SELECT extID, userName FROM levels WHERE levelID = :levelID');
         $query->execute(['levelID' => $levelid]);
         $levelData = $query->fetch(PDO::FETCH_ASSOC);
-        if ($levelData) {
-		    $extIDvalue = $levelData['extID'];
-		    $levelUserName = $levelData['userName'];
-            $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
-            $query->execute(['extID' => $extIDvalue]);
-            $userData = $query->fetch(PDO::FETCH_ASSOC);
-            if ($userData && $userData['userName'] === $levelUserName) {
-            	$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
-                $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
-                $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
-                $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">';
-            }
+		$extIDvalue = $level['extID'];
+		$levelUserName = $level['userName'];
+        $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+        $query->execute(['extID' => $extIDvalue]);
+        $userData = $query->fetch(PDO::FETCH_ASSOC);
+        if($userData) {
+            $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+            $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+            $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+            $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
         }
-        // Badge management
-        $badgeImg = '';
-        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
-        $query->execute(['levelID' => $level['levelID']]);
-        $extID = $query->fetchColumn();
-        if ($extID !== false) {
-            $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
-            $query->execute(['extID' => $extID]);
-            $roleData = $query->fetch(PDO::FETCH_ASSOC);
-            if ($roleData) {
-                $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
-                $query->execute(['roleID' => $roleData['roleID']]);
-                $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
-                if ($roleInfo) {
-                    $modBadgeLevel = $roleInfo['modBadgeLevel'];
-                    if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
-                        $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
-                    }
-                }
-            }
-        }	
 		$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"]).'
-                        '.$avatarImg.'
-					    '.$badgeImg.'
-                        </h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/dailyTable.php
+++ b/dashboard/stats/dailyTable.php
@@ -78,12 +78,54 @@ foreach($result as &$daily){
 		$dt = '<p class="profilepic"><i class="fa-regular fa-clock"></i> '.$dtt.'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$level['downloads'].'</p>';
 		$all = $dailyl.$dt.$dls.$stats.$st.$ln.$lp.$rs;
+        // Avatar management
+	    $avatarImg = '';
+        $query = $db->prepare('SELECT extID, userName FROM levels WHERE levelID = :levelID');
+        $query->execute(['levelID' => $levelid]);
+        $levelData = $query->fetch(PDO::FETCH_ASSOC);
+        if ($levelData) {
+		    $extIDvalue = $levelData['extID'];
+		    $levelUserName = $levelData['userName'];
+            $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+            $query->execute(['extID' => $extIDvalue]);
+            $userData = $query->fetch(PDO::FETCH_ASSOC);
+            if ($userData && $userData['userName'] === $levelUserName) {
+            	$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+                $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+                $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+                $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">';
+            }
+        }
+        // Badge management
+        $badgeImg = '';
+        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
+        $query->execute(['levelID' => $level['levelID']]);
+        $extID = $query->fetchColumn();
+        if ($extID !== false) {
+            $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
+            $query->execute(['extID' => $extID]);
+            $roleData = $query->fetch(PDO::FETCH_ASSOC);
+            if ($roleData) {
+                $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
+                $query->execute(['roleID' => $roleData['roleID']]);
+                $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
+                if ($roleInfo) {
+                    $modBadgeLevel = $roleInfo['modBadgeLevel'];
+                    if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
+                        $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
+                    }
+                }
+            }
+        }	
 		$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"]).'
+                        '.$avatarImg.'
+					    '.$badgeImg.'
+                        </h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/gauntletTable.php
+++ b/dashboard/stats/gauntletTable.php
@@ -7,6 +7,7 @@ $gs = new mainLib();
 $dl->title($dl->getLocalizedString("gauntletTable"));
 $dl->printFooter('../');
 include "../".$dbPath."incl/lib/connection.php";
+include "../".$dbPath."incl/lib/exploitPatch.php";
 $x = 1;
 $packtable = "";
 $query = $db->prepare("SELECT * FROM gauntlets ORDER BY ID ASC");
@@ -34,7 +35,7 @@ foreach($result as &$pack){
 		$levelid = $action["levelID"];
 		$levelname = $action["levelName"];
 		$levelIDlol = '<button id="copy'.$action["levelID"].'" class="accbtn songidyeah" onclick="copysong('.$action["levelID"].')">'.$action["levelID"].'</button>';
-		$levelDesc = htmlspecialchars(base64_decode($action["levelDesc"]));
+		$levelDesc = htmlspecialchars(ExploitPatch::url_base64_decode($action["levelDesc"]));
 		if(empty($levelDesc)) $levelDesc = '<text style="color:gray">'.$dl->getLocalizedString("noDesc").'</text>';
 		$levelpass = $action["password"];
 		$likes = $action["likes"];
@@ -63,12 +64,25 @@ foreach($result as &$pack){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $action['extID'];
+		$levelUserName = $action['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$lvltable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/levelsList.php
+++ b/dashboard/stats/levelsList.php
@@ -105,12 +105,53 @@ foreach($result as &$action){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
+
+        // Avatar management
+        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
+        $query->execute(['levelID' => $levelid]);
+        $extIDvalue = $query->fetchColumn();
+        if ($extIDvalue !== false) {
+            $query = $db->prepare('SELECT iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+            $query->execute(['extID' => $extIDvalue]);
+            $userData = $query->fetch(PDO::FETCH_ASSOC);
+            if ($userData) {
+                $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+                $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+                $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+                $avatarImg = 'https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '';
+            }
+        }
+
+        // Badge management
+        $badgeImg = '';
+        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
+        $query->execute(['levelID' => $action['levelID']]);
+        $extID = $query->fetchColumn();
+        if ($extID !== false) {
+            $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
+            $query->execute(['extID' => $extID]);
+            $roleData = $query->fetch(PDO::FETCH_ASSOC);
+            if ($roleData) {
+                $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
+                $query->execute(['roleID' => $roleData['roleID']]);
+                $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
+                if ($roleInfo) {
+                    $modBadgeLevel = $roleInfo['modBadgeLevel'];
+                    if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
+                        $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
+                    }
+                }
+            }
+        }	
 	$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'
+                                        <img src="'.$avatarImg.'" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">
+					'.$badgeImg.'
+                                    </h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/levelsList.php
+++ b/dashboard/stats/levelsList.php
@@ -105,55 +105,26 @@ foreach($result as &$action){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
-    // Avatar management
+	// Avatar management
 	$avatarImg = '';
-    $query = $db->prepare('SELECT extID, userName FROM levels WHERE levelID = :levelID');
-    $query->execute(['levelID' => $levelid]);
-    $levelData = $query->fetch(PDO::FETCH_ASSOC);
-    if ($levelData) {
-		$extIDvalue = $levelData['extID'];
-		$levelUserName = $levelData['userName'];
-        $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
-        $query->execute(['extID' => $extIDvalue]);
-        $userData = $query->fetch(PDO::FETCH_ASSOC);
-        if ($userData && $userData['userName'] === $levelUserName) {
-            $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
-            $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
-            $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
-            $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">';
-        }
+	$extIDvalue = $action['extID'];
+	$levelUserName = $action['userName'];
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $extIDvalue]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
     }
-    // Badge management
-    $badgeImg = '';
-    $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
-    $query->execute(['levelID' => $action['levelID']]);
-    $extID = $query->fetchColumn();
-    if ($extID !== false) {
-        $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
-        $query->execute(['extID' => $extID]);
-        $roleData = $query->fetch(PDO::FETCH_ASSOC);
-        if ($roleData) {
-            $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
-            $query->execute(['roleID' => $roleData['roleID']]);
-            $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
-            if ($roleInfo) {
-                $modBadgeLevel = $roleInfo['modBadgeLevel'];
-                if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
-                    $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
-                }
-            }
-        }
-    }	
 	$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'
-                        '.$avatarImg.'
-					    '.$badgeImg.'
-                        </h1>
-        			</div>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
+					</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>
     			<div class="form-control acccontrol">

--- a/dashboard/stats/levelsList.php
+++ b/dashboard/stats/levelsList.php
@@ -105,53 +105,54 @@ foreach($result as &$action){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
-
-        // Avatar management
-        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
-        $query->execute(['levelID' => $levelid]);
-        $extIDvalue = $query->fetchColumn();
-        if ($extIDvalue !== false) {
-            $query = $db->prepare('SELECT iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
-            $query->execute(['extID' => $extIDvalue]);
-            $userData = $query->fetch(PDO::FETCH_ASSOC);
-            if ($userData) {
-                $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
-                $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
-                $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
-                $avatarImg = 'https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '';
-            }
+    // Avatar management
+	$avatarImg = '';
+    $query = $db->prepare('SELECT extID, userName FROM levels WHERE levelID = :levelID');
+    $query->execute(['levelID' => $levelid]);
+    $levelData = $query->fetch(PDO::FETCH_ASSOC);
+    if ($levelData) {
+		$extIDvalue = $levelData['extID'];
+		$levelUserName = $levelData['userName'];
+        $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+        $query->execute(['extID' => $extIDvalue]);
+        $userData = $query->fetch(PDO::FETCH_ASSOC);
+        if ($userData && $userData['userName'] === $levelUserName) {
+            $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+            $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+            $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+            $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">';
         }
-
-        // Badge management
-        $badgeImg = '';
-        $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
-        $query->execute(['levelID' => $action['levelID']]);
-        $extID = $query->fetchColumn();
-        if ($extID !== false) {
-            $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
-            $query->execute(['extID' => $extID]);
-            $roleData = $query->fetch(PDO::FETCH_ASSOC);
-            if ($roleData) {
-                $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
-                $query->execute(['roleID' => $roleData['roleID']]);
-                $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
-                if ($roleInfo) {
-                    $modBadgeLevel = $roleInfo['modBadgeLevel'];
-                    if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
-                        $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
-                    }
+    }
+    // Badge management
+    $badgeImg = '';
+    $query = $db->prepare('SELECT extID FROM levels WHERE levelID = :levelID');
+    $query->execute(['levelID' => $action['levelID']]);
+    $extID = $query->fetchColumn();
+    if ($extID !== false) {
+        $query = $db->prepare('SELECT r.accountID, r.roleID FROM roleassign r INNER JOIN users u ON r.accountID = u.extID WHERE u.extID = :extID');
+        $query->execute(['extID' => $extID]);
+        $roleData = $query->fetch(PDO::FETCH_ASSOC);
+        if ($roleData) {
+            $query = $db->prepare('SELECT modBadgeLevel FROM roles WHERE roleID = :roleID');
+            $query->execute(['roleID' => $roleData['roleID']]);
+            $roleInfo = $query->fetch(PDO::FETCH_ASSOC);
+            if ($roleInfo) {
+                $modBadgeLevel = $roleInfo['modBadgeLevel'];
+                if ($modBadgeLevel > 1 && $modBadgeLevel < 3) {
+                    $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-top: -12px; margin-left: -9px; vertical-align: middle;">';
                 }
             }
-        }	
+        }
+    }	
 	$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
         				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'
-                                        <img src="'.$avatarImg.'" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; margin-left: -4px; object-fit: contain;">
-					'.$badgeImg.'
-                                    </h1>
+                        '.$avatarImg.'
+					    '.$badgeImg.'
+                        </h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/listsTable.php
+++ b/dashboard/stats/listsTable.php
@@ -33,7 +33,7 @@ foreach($result as &$pack){
     if($pack["starStars"] == 0) $starspack = '<span style="color:grey">0</span>';
   	$coinspack = $pack["countForReward"];
 	$pst = '<p class="profilepic"><i class="fa-solid fa-gem" style="color:#a6fffb"></i> '.$starspack.'</p>';
-	if($pack["countForReward"] != 0) $pcc =  '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
+	if($pack["countForReward"] != 0) $pcc = '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
 	$pd = '<p class="profilepic"><i class="fa-solid fa-face-smile-beam"></i> '.$gs->getListDiffName($pack['starDifficulty']).'</p>';
 	$lk = '<p class="profilepic"><i class="fa-solid fa-thumbs-'.($pack['likes'] - $pack['dislikes'] >= 0 ? 'up' : 'down').'"></i> '.abs($pack['likes'] - $pack['dislikes']).'</p>';
 	$dload = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270" style="color: #afff9b;"></i> '.$pack['downloads'].'</p>';
@@ -42,6 +42,7 @@ foreach($result as &$pack){
 		$query = $db->prepare("SELECT * FROM levels WHERE levelID = :levelID");
 		$query->execute([':levelID' => $lvl]);
 		$action = $query->fetch();
+		if(!$action) continue;
 		$levelid = $action["levelID"];
 		$levelname = $action["levelName"];
 		$levelIDlol = '<button id="copy'.$action["levelID"].'" class="accbtn songidyeah" onclick="copysong('.$action["levelID"].')">'.$action["levelID"].'</button>';
@@ -75,12 +76,25 @@ foreach($result as &$pack){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $action['extID'];
+		$levelUserName = $action['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$lvltable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>
@@ -94,10 +108,21 @@ foreach($result as &$pack){
 			<div style="display: flex;justify-content: space-between;margin-top: 10px;"><h3 id="comments" class="songidyeah" style="margin: 0px;width: max-content;align-items: center;">'.$dl->getLocalizedString("levelid").': <b>'.$levelIDlol.'</b></h3><h3 id="comments" class="songidyeah"  style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3></div>
 		</div></div>';
 	}
+	// Avatar management
+	$avatarImg = '';
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $pack["accountID"]]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$packtable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 		<div class="profile packcard">
 			<div class="packname">
-				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID']))).'</h1>
+				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID'])), $avatarImg).'</h1>
 				<p>'.$listDesc.'</p>
 			</div>
 			<div class="form-control longfc">

--- a/dashboard/stats/listsTableMod.php
+++ b/dashboard/stats/listsTableMod.php
@@ -41,7 +41,7 @@ foreach($result as &$pack){
     if($pack["starStars"] == 0) $starspack = '<span style="color:grey">0</span>';
   	$coinspack = $pack["countForReward"];
 	$pst = '<p class="profilepic"><i class="fa-solid fa-gem"></i> '.$starspack.'</p>';
-	if($pack["countForReward"] != 0) $pcc =  '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
+	if($pack["countForReward"] != 0) $pcc = '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
 	$pd = '<p class="profilepic"><i class="fa-solid fa-face-smile-beam"></i> '.$gs->getListDiffName($pack['starDifficulty']).'</p>';
 	$lk = '<p class="profilepic"><i class="fa-solid fa-thumbs-'.($pack['likes'] - $pack['dislikes'] > 0 ? 'up' : 'down').'"></i> '.abs($pack['likes'] - $pack['dislikes']).'</p>';
 	$dload = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$pack['downloads'].'</p>';
@@ -50,6 +50,7 @@ foreach($result as &$pack){
 		$query = $db->prepare("SELECT * FROM levels WHERE levelID = :levelID");
 		$query->execute([':levelID' => $lvl]);
 		$action = $query->fetch();
+		if(!$action) continue;
 		$levelid = $action["levelID"];
 		$levelname = $action["levelName"];
 		$levelIDlol = '<button id="copy'.$action["levelID"].'" class="accbtn songidyeah" onclick="copysong('.$action["levelID"].')">'.$action["levelID"].'</button>';
@@ -83,12 +84,25 @@ foreach($result as &$pack){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $action['extID'];
+		$levelUserName = $action['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$lvltable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>
@@ -102,10 +116,21 @@ foreach($result as &$pack){
 			<div style="display: flex;justify-content: space-between;margin-top: 10px;"><h3 id="comments" class="songidyeah" style="margin: 0px;width: max-content;align-items: center;">'.$dl->getLocalizedString("levelid").': <b>'.$levelIDlol.'</b></h3><h3 id="comments" class="songidyeah"  style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3></div>
 		</div></div>';
 	}
+	// Avatar management
+	$avatarImg = '';
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $pack["accountID"]]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$packtable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 		<div class="profile packcard">
 			<div class="packname">
-				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID']))).'</h1>
+				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID'])), $avatarImg).'</h1>
 				<p>'.$listDesc.'</p>
 			</div>
 			<div class="form-control longfc">

--- a/dashboard/stats/listsTableYour.php
+++ b/dashboard/stats/listsTableYour.php
@@ -40,7 +40,7 @@ foreach($result as &$pack){
     if($pack["starStars"] == 0) $starspack = '<span style="color:grey">0</span>';
   	$coinspack = $pack["countForReward"];
 	$pst = '<p class="profilepic"><i class="fa-solid fa-gem"></i> '.$starspack.'</p>';
-	if($pack["countForReward"] != 0) $pcc =  '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
+	if($pack["countForReward"] != 0) $pcc = '<p class="profilepic"><i class="fa-solid fa-circle-check"></i> '.$coinspack.'</p>'; else $pcc = '';
 	$pd = '<p class="profilepic"><i class="fa-solid fa-face-smile-beam"></i> '.$gs->getListDiffName($pack['starDifficulty']).'</p>';
 	$lk = '<p class="profilepic"><i class="fa-solid fa-thumbs-'.($pack['likes'] - $pack['dislikes'] > 0 ? 'up' : 'down').'"></i> '.abs($pack['likes'] - $pack['dislikes']).'</p>';
 	$dload = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$pack['downloads'].'</p>';
@@ -49,6 +49,7 @@ foreach($result as &$pack){
 		$query = $db->prepare("SELECT * FROM levels WHERE levelID = :levelID");
 		$query->execute([':levelID' => $lvl]);
 		$action = $query->fetch();
+		if(!$action) continue;
 		$levelid = $action["levelID"];
 		$levelname = $action["levelName"];
 		$levelIDlol = '<button id="copy'.$action["levelID"].'" class="accbtn songidyeah" onclick="copysong('.$action["levelID"].')">'.$action["levelID"].'</button>';
@@ -82,12 +83,25 @@ foreach($result as &$pack){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $action['extID'];
+		$levelUserName = $action['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$lvltable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>
@@ -101,10 +115,21 @@ foreach($result as &$pack){
 			<div style="display: flex;justify-content: space-between;margin-top: 10px;"><h3 id="comments" class="songidyeah" style="margin: 0px;width: max-content;align-items: center;">'.$dl->getLocalizedString("levelid").': <b>'.$levelIDlol.'</b></h3><h3 id="comments" class="songidyeah"  style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3></div>
 		</div></div>';
 	}
+	// Avatar management
+	$avatarImg = '';
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $pack["accountID"]]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$packtable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 		<div class="profile packcard">
 			<div class="packname">
-				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID']))).'</h1>
+				<h1>'.sprintf($dl->getLocalizedString("demonlistLevel"), htmlspecialchars($pack["listName"]), 0, htmlspecialchars($gs->getAccountName($pack['accountID'])), $avatarImg).'</h1>
 				<p>'.$listDesc.'</p>
 			</div>
 			<div class="form-control longfc">

--- a/dashboard/stats/modActionsList.php
+++ b/dashboard/stats/modActionsList.php
@@ -180,56 +180,35 @@ foreach($result as &$action){
 	$v2 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-2" style="background: #29282c; padding: 5px 9.5px; border-radius: 500px;"></i> '.$value2.'</div></div>';
 	$v3 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-3" style="background: #29282c; padding: 5px 6.5px; border-radius: 500px;"></i> '.$value3.'</div></div>';
 	$stats = $v1.$v2.$v3;
-        // Avatar management
-        $queryUserDetails = $db->prepare("SELECT u.iconType, u.accIcon, u.accShip, u.accBall, u.accBird, u.accDart, u.accRobot, u.accSpider, u.accSwing, u.accJetpack, u.color1, u.color2, u.color3, u.accGlow FROM users u JOIN modactions m ON u.extID = m.account WHERE m.account = :accountID");
-        $queryUserDetails->execute([':accountID' => $action['account']]);
-        if ($userDetails = $queryUserDetails->fetch(PDO::FETCH_ASSOC)) {
-            $iconType = ($userDetails['iconType'] > 8) ? 0 : $userDetails['iconType'];
-            $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userDetails['accIcon']], 1 => ['type' => 'ship', 'value' => $userDetails['accShip']], 2 => ['type' => 'ball', 'value' => $userDetails['accBall']], 3 => ['type' => 'ufo', 'value' => $userDetails['accBird']], 4 => ['type' => 'wave', 'value' => $userDetails['accDart']], 5 => ['type' => 'robot', 'value' => $userDetails['accRobot']], 6 => ['type' => 'spider', 'value' => $userDetails['accSpider']], 7 => ['type' => 'swing', 'value' => $userDetails['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userDetails['accJetpack']]];
-            $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-            $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userDetails['color1'] . '&color2=' . $userDetails['color2'] . ($userDetails['accGlow'] != 0 ? '&glow=' . $userDetails['accGlow'] . '&color3=' . $userDetails['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: -5px; object-fit: contain;">';
-        }
-        // Badge management
-        $badgeImg = '';
-        $queryAccountID = $db->prepare("SELECT ra.roleID, u.extID FROM roleassign ra JOIN users u ON ra.accountID = u.extID WHERE ra.accountID = :account");
-        $queryAccountID->execute([':account' => $action['account']]);
-        if ($accountData = $queryAccountID->fetch(PDO::FETCH_ASSOC)) {
-            $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
-            $queryBadgeLevel->execute([':roleID' => $accountData['roleID']]);
-            if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
-                $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-left: 3px; margin-top: -12px; margin-left: -2px; vertical-align: middle;">';
-            }
-       }
-        $members .= '<div style="width: 100%; display: flex; flex-wrap: wrap; justify-content: center;">
-            <div class="profile" style="width: 100%;">
-                <div style="display: flex; align-items: center; margin-bottom: 7px;">
-                    <!-- Container for both avatars and username -->
-                    <div style="display: flex; align-items: center;">
-                        <!-- First Avatar -->
-                        '.$avatarImg.'
-                        <!-- Space between first avatar and second avatar -->
-                        <div style="margin-left: 7px;">
-                            <!-- Second Avatar -->
-                            '.$badgeImg.'
-                        </div>
-                        <!-- Space between second avatar and username -->
-                        <div style="margin-left: 4px;">
-                            <h1 class="dlh1 profh1 suggest" style="margin: 0;">
-                                <button type="button" onclick="a(\'profile/'.$account.'\', true, true)" class="accbtn" name="accountID">'.$account.'</button>
-                                <text class="dltext"> '.$actionname.'</text>
-                            </h1>
-                        </div>
+	// Avatar management
+    $queryUserDetails = $db->prepare("SELECT u.iconType, u.accIcon, u.accShip, u.accBall, u.accBird, u.accDart, u.accRobot, u.accSpider, u.accSwing, u.accJetpack, u.color1, u.color2, u.color3, u.accGlow FROM users u JOIN modactions m ON u.extID = m.account WHERE m.account = :accountID");
+    $queryUserDetails->execute([':accountID' => $action['account']]);
+    if($userDetails = $queryUserDetails->fetch(PDO::FETCH_ASSOC)) {
+        $iconType = ($userDetails['iconType'] > 8) ? 0 : $userDetails['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userDetails['accIcon']], 1 => ['type' => 'ship', 'value' => $userDetails['accShip']], 2 => ['type' => 'ball', 'value' => $userDetails['accBall']], 3 => ['type' => 'ufo', 'value' => $userDetails['accBird']], 4 => ['type' => 'wave', 'value' => $userDetails['accDart']], 5 => ['type' => 'robot', 'value' => $userDetails['accRobot']], 6 => ['type' => 'spider', 'value' => $userDetails['accSpider']], 7 => ['type' => 'swing', 'value' => $userDetails['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userDetails['accJetpack']]];
+        $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userDetails['color1'] . '&color2=' . $userDetails['color2'] . ($userDetails['accGlow'] != 0 ? '&glow=' . $userDetails['accGlow'] . '&color3=' . $userDetails['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 5px; object-fit: contain;">';
+    }
+    $members .= '<div style="width: 100%; display: flex; flex-wrap: wrap; justify-content: center;">
+        <div class="profile" style="width: 100%;">
+            <div style="display: flex; align-items: center; margin-bottom: 7px;">
+                <div style="display: flex; align-items: center;">
+                    '.$avatarImg.'
+                    <div>
+                        <h1 class="dlh1 profh1 suggest" style="margin: 0;">
+                            <button type="button" onclick="a(\'profile/'.$account.'\', true, true)" class="accbtn" name="accountID">'.$account.'</button>
+                            <text class="dltext"> '.$actionname.'</text>
+                        </h1>
                     </div>
                 </div>
-                <!-- Stats section -->
-                <div class="form-control" style="display: flex; width: 100%; height: max-content; align-items: center;">'.$stats.'</div>
-                <!-- Comments section -->
-                <div class="acccomments">
-                    <h3 class="comments" style="margin: 0; width: max-content;">'.$dl->getLocalizedString("ID").':&nbsp;<b>'.$action["ID"].'</b></h3>
-                    <h3 class="comments" style="justify-content: flex-end; grid-gap: 0.5vh; margin: 0; width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3>
-                </div>
             </div>
-        </div>';
+            <div class="form-control" style="display: flex; width: 100%; height: max-content; align-items: center;">'.$stats.'</div>
+            <div class="acccomments">
+                <h3 class="comments" style="margin: 0; width: max-content;">'.$dl->getLocalizedString("ID").':&nbsp;<b>'.$action["ID"].'</b></h3>
+                <h3 class="comments" style="justify-content: flex-end; grid-gap: 0.5vh; margin: 0; width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3>
+            </div>
+        </div>
+    </div>';
 	$x++;
 }
 $mods = $db->prepare("SELECT * FROM roleassign GROUP BY accountID");

--- a/dashboard/stats/modActionsList.php
+++ b/dashboard/stats/modActionsList.php
@@ -180,13 +180,59 @@ foreach($result as &$action){
 	$v2 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-2" style="background: #29282c; padding: 5px 9.5px; border-radius: 500px;"></i> '.$value2.'</div></div>';
 	$v3 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-3" style="background: #29282c; padding: 5px 6.5px; border-radius: 500px;"></i> '.$value3.'</div></div>';
 	$stats = $v1.$v2.$v3;
-	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
-			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><div class="acclistdiv">
-				<h1 class="dlh1 profh1 suggest"><button type="button" onclick="a(\'profile/'.$account.'\', true, true)" class="accbtn" name="accountID">'.$account.'</button><text class="dltext"> '.$actionname.'</text></h1>
-			</div></div>
-			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
-			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("ID").': <b>'.$action["ID"].'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3></div>
-		</div></div>';
+
+        // Avatar management
+        $queryUserDetails = $db->prepare("SELECT u.iconType, u.accIcon, u.accShip, u.accBall, u.accBird, u.accDart, u.accRobot, u.accSpider, u.accSwing, u.accJetpack, u.color1, u.color2, u.color3, u.accGlow FROM users u JOIN modactions m ON u.extID = m.account WHERE m.account = :accountID");
+        $queryUserDetails->execute([':accountID' => $action['account']]);
+        if ($userDetails = $queryUserDetails->fetch(PDO::FETCH_ASSOC)) {
+            $iconType = ($userDetails['iconType'] > 8) ? 0 : $userDetails['iconType'];
+            $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userDetails['accIcon']], 1 => ['type' => 'ship', 'value' => $userDetails['accShip']], 2 => ['type' => 'ball', 'value' => $userDetails['accBall']], 3 => ['type' => 'ufo', 'value' => $userDetails['accBird']], 4 => ['type' => 'wave', 'value' => $userDetails['accDart']], 5 => ['type' => 'robot', 'value' => $userDetails['accRobot']], 6 => ['type' => 'spider', 'value' => $userDetails['accSpider']], 7 => ['type' => 'swing', 'value' => $userDetails['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userDetails['accJetpack']]];
+            $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+            $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userDetails['color1'] . '&color2=' . $userDetails['color2'] . ($userDetails['accGlow'] != 0 ? '&glow=' . $userDetails['accGlow'] . '&color3=' . $userDetails['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: -5px; object-fit: contain;">';
+        }
+
+        // Badge management
+        $badgeImg = '';
+        $queryAccountID = $db->prepare("SELECT ra.roleID, u.extID FROM roleassign ra JOIN users u ON ra.accountID = u.extID WHERE ra.accountID = :account");
+        $queryAccountID->execute([':account' => $action['account']]);
+        if ($accountData = $queryAccountID->fetch(PDO::FETCH_ASSOC)) {
+            $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+            $queryBadgeLevel->execute([':roleID' => $accountData['roleID']]);
+            if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+                $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-left: 3px; margin-top: -12px; margin-left: -2px; vertical-align: middle;">';
+            }
+       }
+
+        $members .= '<div style="width: 100%; display: flex; flex-wrap: wrap; justify-content: center;">
+            <div class="profile" style="width: 100%;">
+                <div style="display: flex; align-items: center; margin-bottom: 7px;">
+                    <!-- Container for both avatars and username -->
+                    <div style="display: flex; align-items: center;">
+                        <!-- First Avatar -->
+                        '.$avatarImg.'
+                        <!-- Space between first avatar and second avatar -->
+                        <div style="margin-left: 7px;">
+                            <!-- Second Avatar -->
+                            '.$badgeImg.'
+                        </div>
+                        <!-- Space between second avatar and username -->
+                        <div style="margin-left: 4px;">
+                            <h1 class="dlh1 profh1 suggest" style="margin: 0;">
+                                <button type="button" onclick="a(\'profile/'.$account.'\', true, true)" class="accbtn" name="accountID">'.$account.'</button>
+                                <text class="dltext"> '.$actionname.'</text>
+                            </h1>
+                        </div>
+                    </div>
+                </div>
+                <!-- Stats section -->
+                <div class="form-control" style="display: flex; width: 100%; height: max-content; align-items: center;">'.$stats.'</div>
+                <!-- Comments section -->
+                <div class="acccomments">
+                    <h3 class="comments" style="margin: 0; width: max-content;">'.$dl->getLocalizedString("ID").':&nbsp;<b>'.$action["ID"].'</b></h3>
+                    <h3 class="comments" style="justify-content: flex-end; grid-gap: 0.5vh; margin: 0; width: max-content;">'.$dl->getLocalizedString("date").': <b>'.$time.'</b></h3>
+                </div>
+            </div>
+        </div>';
 	$x++;
 }
 $mods = $db->prepare("SELECT * FROM roleassign GROUP BY accountID");

--- a/dashboard/stats/modActionsList.php
+++ b/dashboard/stats/modActionsList.php
@@ -180,7 +180,6 @@ foreach($result as &$action){
 	$v2 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-2" style="background: #29282c; padding: 5px 9.5px; border-radius: 500px;"></i> '.$value2.'</div></div>';
 	$v3 = '<div class="mavdiv"><div class="profilepic"><i class="fa-solid fa-3" style="background: #29282c; padding: 5px 6.5px; border-radius: 500px;"></i> '.$value3.'</div></div>';
 	$stats = $v1.$v2.$v3;
-
         // Avatar management
         $queryUserDetails = $db->prepare("SELECT u.iconType, u.accIcon, u.accShip, u.accBall, u.accBird, u.accDart, u.accRobot, u.accSpider, u.accSwing, u.accJetpack, u.color1, u.color2, u.color3, u.accGlow FROM users u JOIN modactions m ON u.extID = m.account WHERE m.account = :accountID");
         $queryUserDetails->execute([':accountID' => $action['account']]);
@@ -190,7 +189,6 @@ foreach($result as &$action){
             $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
             $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userDetails['color1'] . '&color2=' . $userDetails['color2'] . ($userDetails['accGlow'] != 0 ? '&glow=' . $userDetails['accGlow'] . '&color3=' . $userDetails['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: -5px; object-fit: contain;">';
         }
-
         // Badge management
         $badgeImg = '';
         $queryAccountID = $db->prepare("SELECT ra.roleID, u.extID FROM roleassign ra JOIN users u ON ra.accountID = u.extID WHERE ra.accountID = :account");
@@ -202,7 +200,6 @@ foreach($result as &$action){
                 $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 23px; height: 23px; margin-left: 3px; margin-top: -12px; margin-left: -2px; vertical-align: middle;">';
             }
        }
-
         $members .= '<div style="width: 100%; display: flex; flex-wrap: wrap; justify-content: center;">
             <div class="profile" style="width: 100%;">
                 <div style="display: flex; align-items: center; margin-bottom: 7px;">

--- a/dashboard/stats/modList.php
+++ b/dashboard/stats/modList.php
@@ -48,13 +48,29 @@ foreach($result as &$action) {
 		if($claninfo["clanOwner"] == $action["accountID"]) $own = '<i style="color:#ffff91" class="fa-solid fa-crown"></i>';
 		$clan = '<span style="display:contents;cursor:pointer"><h2 class="music" style="width: max-content;margin-left: 5px;grid-gap:5px;color:#'.$claninfo["color"].'">'.$claninfo["clan"].$own.'</h2></span>';
 	}
+	        $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
+        $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+
+        // Badge management
+        $badgeImg = '';
+        $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
+        $queryRoleID->execute([':accountID' => $accountID]);	
+        if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+            $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+            $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
+            if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+                $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
+            }
+        }	
 	$ac = '<p class="profilepic">'.$counts["actionCount"].' <i class="fa-solid fa-circle-play"></i></p>';
-    $lr = '<p class="profilepic">'.$counts["levelsRated"].' <i class="fa-regular fa-star"></i></p>';
+        $lr = '<p class="profilepic">'.$counts["levelsRated"].' <i class="fa-regular fa-star"></i></p>';
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0, false).$ac.$lr;
 	$registerDate = $dl->convertToDate($action["registerDate"], true);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$action["userName"].' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/modList.php
+++ b/dashboard/stats/modList.php
@@ -48,22 +48,22 @@ foreach($result as &$action) {
 		if($claninfo["clanOwner"] == $action["accountID"]) $own = '<i style="color:#ffff91" class="fa-solid fa-crown"></i>';
 		$clan = '<span style="display:contents;cursor:pointer"><h2 class="music" style="width: max-content;margin-left: 5px;grid-gap:5px;color:#'.$claninfo["color"].'">'.$claninfo["clan"].$own.'</h2></span>';
 	}
-	        $iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
-        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
-        $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
-
-        // Badge management
-        $badgeImg = '';
-        $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
-        $queryRoleID->execute([':accountID' => $accountID]);	
-        if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
-            $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
-            $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
-            if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
-                $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
-            }
-        }	
+	// Avatar management
+	$iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
+    $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
+    $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
+    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+    // Badge management
+    $badgeImg = '';
+    $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
+    $queryRoleID->execute([':accountID' => $accountID]);	
+    if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+        $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
+        $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
+        if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
+        }
+    }	
 	$ac = '<p class="profilepic">'.$counts["actionCount"].' <i class="fa-solid fa-circle-play"></i></p>';
         $lr = '<p class="profilepic">'.$counts["levelsRated"].' <i class="fa-regular fa-star"></i></p>';
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0, false).$ac.$lr;

--- a/dashboard/stats/modList.php
+++ b/dashboard/stats/modList.php
@@ -52,25 +52,25 @@ foreach($result as &$action) {
 	$iconType = ($action['iconType'] > 8) ? 0 : $action['iconType'];
     $iconTypeMap = [0 => ['type' => 'cube', 'value' => $action['accIcon']], 1 => ['type' => 'ship', 'value' => $action['accShip']], 2 => ['type' => 'ball', 'value' => $action['accBall']], 3 => ['type' => 'ufo', 'value' => $action['accBird']], 4 => ['type' => 'wave', 'value' => $action['accDart']], 5 => ['type' => 'robot', 'value' => $action['accRobot']], 6 => ['type' => 'spider', 'value' => $action['accSpider']], 7 => ['type' => 'swing', 'value' => $action['accSwing']], 8 => ['type' => 'jetpack', 'value' => $action['accJetpack']]];
     $iconValue = $iconTypeMap[$iconType]['value'] ?: 1;
-    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; margin-right: 10px; object-fit: contain;">';
+    $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $action['color1'] . '&color2=' . $action['color2'] . ($action['accGlow'] != 0 ? '&glow=' . $action['accGlow'] . '&color3=' . $action['color3'] : '') . '" alt="avatar" style="width: 31px; object-fit: contain;">';
     // Badge management
     $badgeImg = '';
     $queryRoleID = $db->prepare("SELECT roleID FROM roleassign WHERE accountID = :accountID");
     $queryRoleID->execute([':accountID' => $accountID]);	
-    if ($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
+    if($roleAssignData = $queryRoleID->fetch(PDO::FETCH_ASSOC)) {        
         $queryBadgeLevel = $db->prepare("SELECT modBadgeLevel FROM roles WHERE roleID = :roleID");
         $queryBadgeLevel->execute([':roleID' => $roleAssignData['roleID']]);	    
-        if (($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
-            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: 7px; margin-top: -3px; vertical-align: middle;">';
+        if(($modBadgeLevel = $queryBadgeLevel->fetchColumn() ?? 0) >= 1 && $modBadgeLevel <= 3) {
+            $badgeImg = '<img src="https://raw.githubusercontent.com/Fenix668/GMDprivateServer/master/dashboard/modBadge_0' . $modBadgeLevel . '_001.png" alt="badge" style="width: 34px; height: 34px; margin-left: -3px; margin-top: -3px; vertical-align: middle;">';
         }
     }	
 	$ac = '<p class="profilepic">'.$counts["actionCount"].' <i class="fa-solid fa-circle-play"></i></p>';
-        $lr = '<p class="profilepic">'.$counts["levelsRated"].' <i class="fa-regular fa-star"></i></p>';
+    $lr = '<p class="profilepic">'.$counts["levelsRated"].' <i class="fa-regular fa-star"></i></p>';
 	$stats = $dl->createProfileStats($action['stars'], $action['moons'], $action['diamonds'], $action['coins'], $action['userCoins'], $action['demons'], $action['creatorPoints'], 0, false).$ac.$lr;
 	$registerDate = $dl->convertToDate($action["registerDate"], true);
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.' '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($action["accountID"]).');" class="profilenick acclistnick"><div class="accounts-badge-icon-div">'.$avatarImg.' '.$action["userName"].' '.$badgeImg.'</div> '.$clan.'</h2><h2 class="accresultrole">'.$resultRole.'</h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$accountID.'</b></h3><h3 class="comments" style="justify-content: flex-end;grid-gap: 0.5vh;margin: 0px;width: max-content;">'.$dl->getLocalizedString("registerDate").': <b>'.$registerDate.'</b></h3></div>

--- a/dashboard/stats/packTable.php
+++ b/dashboard/stats/packTable.php
@@ -73,12 +73,25 @@ foreach($result as &$pack){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $action['extID'];
+		$levelUserName = $action['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$lvltable .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/reportMod.php
+++ b/dashboard/stats/reportMod.php
@@ -63,12 +63,25 @@ foreach($result as &$level){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($level['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$level['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
+	// Avatar management
+	$avatarImg = '';
+	$extIDvalue = $level['extID'];
+	$levelUserName = $level['userName'];
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $extIDvalue]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$levels = '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 		<div class="profile">
 		<div class="profacclist">
    			<div class="accnamedesc">
        			<div class="profcard1">
-       				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"]).'</h1>
+       				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"], $avatarImg).'</h1>
        			</div>
    			    <p class="dlp">'.$levelDesc.'</p>
    			</div>

--- a/dashboard/stats/suggestList.php
+++ b/dashboard/stats/suggestList.php
@@ -6,6 +6,7 @@ $dl = new dashboardLib();
 require_once "../".$dbPath."incl/lib/mainLib.php";
 $gs = new mainLib();
 include "../".$dbPath."incl/lib/connection.php";
+include "../".$dbPath."incl/lib/exploitPatch.php";
 $dl->title($dl->getLocalizedString("suggestLevels"));
 $dl->printFooter('../');
 $modcheck = $gs->checkPermission($_SESSION["accountID"], "dashboardModTools");
@@ -50,7 +51,7 @@ foreach($result as &$action){
 		$levelid = $level["levelID"];
 		$levelname = $level["levelName"];
 		$levelIDlol = '<button id="copy'.$level["levelID"].'" class="accbtn songidyeah" onclick="copysong('.$level["levelID"].')">'.$level["levelID"].'</button>';
-		$levelDesc = htmlspecialchars(base64_decode($level["levelDesc"]));
+		$levelDesc = htmlspecialchars(ExploitPatch::url_base64_decode($level["levelDesc"]));
 		if(empty($levelDesc)) $levelDesc = '<text style="color:gray">'.$dl->getLocalizedString("noDesc").'</text>';
 		$levelpass = $level["password"];
 		$likes = $level["likes"];
@@ -91,12 +92,25 @@ foreach($result as &$action){
 		$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($level['levelLength']).'</p>';
 		$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$level['downloads'].'</p>';
 		$all = $dls.$stats.$st.$ln.$lp.$rs;
+		// Avatar management
+		$avatarImg = '';
+		$extIDvalue = $level['extID'];
+		$levelUserName = $level['userName'];
+		$query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+		$query->execute(['extID' => $extIDvalue]);
+		$userData = $query->fetch(PDO::FETCH_ASSOC);
+		if($userData) {
+			$iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+			$iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+			$iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+			$avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+		}
 		$levels = '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $level["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/top24h.php
+++ b/dashboard/stats/top24h.php
@@ -70,21 +70,33 @@ foreach($result as &$action){
 	$stats = $dl->createProfileStats($action["stars"], 0, 0, 0, $action['userCoins'], 0, 0, 0);
 	switch($x) {
 		case 1:
-			$place = '<i class="fa-solid fa-trophy" style="color:#ffd700; margin-right: 5px;"> 1</i>';
+			$place = '<i class="fa-solid fa-trophy" style="color:#ffd700;"> 1</i>';
 			break;
 		case 2:
-			$place = '<i class="fa-solid fa-trophy" style="color:#c0c0c0; margin-right: 5px;"> 2</i>';
+			$place = '<i class="fa-solid fa-trophy" style="color:#c0c0c0;"> 2</i>';
 			break;
 		case 3:
-			$place = '<i class="fa-solid fa-trophy" style="color:#cd7f32; margin-right: 5px;"> 3</i>';
+			$place = '<i class="fa-solid fa-trophy" style="color:#cd7f32;"> 3</i>';
 			break;
 		default:
-			$place = '<i class="fa" style="color:white; margin-right: 5px;"># '.$x.'</i>';
+			$place = '<i class="fa" style="color:white;"># '.$x.'</i>';
 			break;
 	}
+	// Avatar management
+	$avatarImg = '';
+	$extIDvalue = $action['extID'];
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $extIDvalue]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$members .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile"><div style="display: flex;width: 100%;justify-content: space-between;margin-bottom: 7px;align-items: center;"><button style="display:contents;cursor:pointer" type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'GET\')"><div class="acclistdiv">
-				<h2 style="color:rgb('.$gs->getAccountCommentColor($userid).'); align-items: baseline;" class="profilenick acclistnick">'.$place.$action["userName"].'</h2>
+				<h2 style="color:rgb('.$gs->getAccountCommentColor($userid).'); align-items: baseline;" class="profilenick acclistnick"><div class="accounts-badge-icon-div">'.$place.$action["userName"].$avatarImg.'</div></h2>
 			</div></button></div>
 			<div class="form-control" style="display: flex;width: 100%;height: max-content;align-items: center;">'.$stats.'</div>
 			<div class="acccomments"><h3 class="comments" style="margin: 0px;width: max-content;">'.$dl->getLocalizedString("accountID").': <b>'.$userid.'</b></h3></div>
@@ -96,7 +108,7 @@ $pagel = '<div class="form new-form">
 <div class="form-control new-form-control">
 		'.$members.'
 	</div></div>';
-$query = $db->prepare("SELECT users.extID, SUM(actions.value) AS stars, users.userName FROM actions INNER JOIN users ON actions.account = users.userID WHERE type = '9' AND timestamp > :time AND users.isBanned = 0 GROUP BY (stars) DESC ORDER BY stars DESC");
+$query = $db->prepare("SELECT users.extID, SUM(actions.value) AS stars, users.userName FROM actions INNER JOIN users ON actions.account = users.userID WHERE type = '9' AND ".$queryText." timestamp > :time  GROUP BY (stars) DESC ORDER BY stars DESC");
 $query->execute([':time' => $time]);
 $packcount = 0;
 $pagecount = ceil($packcount / 10);

--- a/dashboard/stats/unlisted.php
+++ b/dashboard/stats/unlisted.php
@@ -92,12 +92,25 @@ foreach($result as &$action){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
+	// Avatar management
+	$avatarImg = '';
+	$extIDvalue = $action['extID'];
+	$levelUserName = $action['userName'];
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $extIDvalue]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>

--- a/dashboard/stats/unlistedMod.php
+++ b/dashboard/stats/unlistedMod.php
@@ -92,12 +92,25 @@ foreach($result as &$action){
 	$ln = '<p class="profilepic"><i class="fa-solid fa-clock"></i> '.$gs->getLength($action['levelLength']).'</p>';
 	$dls = '<p class="profilepic"><i class="fa-solid fa-reply fa-rotate-270"></i> '.$action['downloads'].'</p>';
 	$all = $dls.$stats.$st.$ln.$lp.$rs;
+	// Avatar management
+	$avatarImg = '';
+	$extIDvalue = $action['extID'];
+	$levelUserName = $action['userName'];
+    $query = $db->prepare('SELECT userName, iconType, color1, color2, color3, accGlow, accIcon, accShip, accBall, accBird, accDart, accRobot, accSpider, accSwing, accJetpack FROM users WHERE extID = :extID');
+    $query->execute(['extID' => $extIDvalue]);
+    $userData = $query->fetch(PDO::FETCH_ASSOC);
+    if($userData) {
+        $iconType = ($userData['iconType'] > 8) ? 0 : $userData['iconType'];
+        $iconTypeMap = [0 => ['type' => 'cube', 'value' => $userData['accIcon']], 1 => ['type' => 'ship', 'value' => $userData['accShip']], 2 => ['type' => 'ball', 'value' => $userData['accBall']], 3 => ['type' => 'ufo', 'value' => $userData['accBird']], 4 => ['type' => 'wave', 'value' => $userData['accDart']], 5 => ['type' => 'robot', 'value' => $userData['accRobot']], 6 => ['type' => 'spider', 'value' => $userData['accSpider']], 7 => ['type' => 'swing', 'value' => $userData['accSwing']], 8 => ['type' => 'jetpack', 'value' => $userData['accJetpack']]];
+        $iconValue = isset($iconTypeMap[$iconType]) ? $iconTypeMap[$iconType]['value'] : 1;	    
+        $avatarImg = '<img src="https://gdicon.oat.zone/icon.png?type=' . $iconTypeMap[$iconType]['type'] . '&value=' . $iconValue . '&color1=' . $userData['color1'] . '&color2=' . $userData['color2'] . ($userData['accGlow'] != 0 ? '&glow=' . $userData['accGlow'] . '&color3=' . $userData['color3'] : '') . '" alt="Avatar" style="width: 30px; height: 30px; vertical-align: middle; object-fit: contain;">';
+    }
 	$levels .= '<div style="width: 100%;display: flex;flex-wrap: wrap;justify-content: center;">
 			<div class="profile">
 			<div class="profacclist">
     			<div class="accnamedesc">
         			<div class="profcard1">
-        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"]).'</h1>
+        				<h1 class="dlh1 profh1">'.sprintf($dl->getLocalizedString("demonlistLevel"), $levelname, 0, $action["userName"], $avatarImg).'</h1>
         			</div>
     			    <p class="dlp">'.$levelDesc.'</p>
     			</div>


### PR DESCRIPTION
Added an avatar icon next to usernames in the account list (dashboard) similar to what is seen in the comments section of the levels. The icon displayed depends on the value of `iconType` in the database, and the link to get the icon was built dynamically based on this value.

It should come out like this:

<img width="545" alt="Screenshot 2024-08-14 232132" src="https://github.com/user-attachments/assets/67e09815-629f-44fa-b9e6-4c45728cb017">

Dashboard like this:

<img width="680" alt="Screenshot 2024-08-14 233620" src="https://github.com/user-attachments/assets/d4708f9d-bd7e-4dc1-8f9a-d704d7f72df8">
