### PR TITLE
The dashboard now counts artists in levels list + some small additions

### DIFF
--- a/dashboard/incl/dashboardLib.php
+++ b/dashboard/incl/dashboardLib.php
@@ -1022,9 +1022,18 @@ class dashboardLib {
 		} else $lp = $rs = '';
 		if($action["songID"] > 0) {
 			$songlol = $gs->getSongInfo($action["songID"]);
-			$songArtists = $gs->getLibrarySongInfo($action["songID"]);
-			$btn = '<button type="button" name="btnsng" id="btn'.$action["songID"].'" title="'.$songlol["authorName"].( !empty($songArtists["artists"]) ? ' +'.count(explode('.', $songArtists["artists"])) : '' ).' — '.$songlol["name"].'" style="display: contents;color: white;margin: 0;" download="'.str_replace('http://', 'https://', $songlol["download"]).'" onclick="btnsong(\''.$action["songID"].'\');"><div class="icon songbtnpic"><i id="icon'.$action["songID"].'" name="iconlol" class="fa-solid fa-play" aria-hidden="false"></i></div></button>';
-			$songid = '<div class="profilepic songpic">'.$btn.'<div class="songfullname"><div class="songauthor">' . $songlol["authorName"] . (!empty($songArtists["artists"]) ? ' +' . (substr_count($songArtists["artists"], ".") + 1) : '') . '</div><div class="songname">'.$songlol["name"].'</div></div></div>';
+			$songArtists = $gs->getLibrarySongInfo($action["songID"])["artists"];
+                $artistIDs = preg_split('/\./', $songArtists);
+                $artistIDs = array_filter($artistIDs);
+                $artistIDsString = implode(', ', $artistIDs);
+                $authorNames = [];
+                foreach ($artistIDs as $id) {
+                    $authorInfo = $gs->getLibrarySongAuthorInfo($id);
+                    $authorNames[] = $authorInfo["name"];
+                }
+                $artistNames = implode(', ', $authorNames);
+                        $btn = '<button type="button" name="btnsng" id="btn'.$action["songID"].'" title="'.($artistNames ? $songlol["authorName"].', '.$artistNames : $songlol["authorName"]).' — '.$songlol["name"].'" style="display: contents;color: white;margin: 0;" download="'.str_replace('http://', 'https://', $songlol["download"]).'" onclick="btnsong(\''.$action["songID"].'\');"><div class="icon songbtnpic"><i id="icon'.$action["songID"].'" name="iconlol" class="fa-solid fa-play" aria-hidden="false"></i></div></button>';
+			$songid = '<div class="profilepic songpic">'.$btn.'<div class="songfullname"><div class="songauthor">'.($artistNames ? $songlol["authorName"].', '.$artistNames : $songlol["authorName"]).'</div><div class="songname">'.$songlol["name"].'</div></div></div>';
 		} else $songid = '<p class="profilepic"><i class="fa-solid fa-music"></i> '.strstr($gs->getAudioTrack($action["audioTrack"]), ' by ', true).'</p>';
 		$username =  '<form style="margin:0" method="post" action="./profile/"><button type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'POST\')" style="margin:0" class="accbtn" name="accountID">'.$action["userName"].'</button></form>';
 		$time = $this->convertToDate($action["uploadDate"], true);

--- a/dashboard/incl/dashboardLib.php
+++ b/dashboard/incl/dashboardLib.php
@@ -1022,8 +1022,9 @@ class dashboardLib {
 		} else $lp = $rs = '';
 		if($action["songID"] > 0) {
 			$songlol = $gs->getSongInfo($action["songID"]);
-			$btn = '<button type="button" name="btnsng" id="btn'.$action["songID"].'" title="'.$songlol["authorName"].' — '.$songlol["name"].'" style="display: contents;color: white;margin: 0;" download="'.str_replace('http://', 'https://', $songlol["download"]).'" onclick="btnsong(\''.$action["songID"].'\');"><div class="icon songbtnpic""><i id="icon'.$action["songID"].'" name="iconlol" class="fa-solid fa-play" aria-hidden="false"></i></div></button>';
-			$songid = '<div class="profilepic songpic">'.$btn.'<div class="songfullname"><div class="songauthor">'.$songlol["authorName"].'</div><div class="songname">'.$songlol["name"].'</div></div></div>';
+			$songArtists = $gs->getLibrarySongInfo($action["songID"]);
+			$btn = '<button type="button" name="btnsng" id="btn'.$action["songID"].'" title="'.$songlol["authorName"].( !empty($songArtists["artists"]) ? ' +'.count(explode('.', $songArtists["artists"])) : '' ).' — '.$songlol["name"].'" style="display: contents;color: white;margin: 0;" download="'.str_replace('http://', 'https://', $songlol["download"]).'" onclick="btnsong(\''.$action["songID"].'\');"><div class="icon songbtnpic"><i id="icon'.$action["songID"].'" name="iconlol" class="fa-solid fa-play" aria-hidden="false"></i></div></button>';
+			$songid = '<div class="profilepic songpic">'.$btn.'<div class="songfullname"><div class="songauthor">' . $songlol["authorName"] . (!empty($songArtists["artists"]) ? ' +' . (substr_count($songArtists["artists"], ".") + 1) : '') . '</div><div class="songname">'.$songlol["name"].'</div></div></div>';
 		} else $songid = '<p class="profilepic"><i class="fa-solid fa-music"></i> '.strstr($gs->getAudioTrack($action["audioTrack"]), ' by ', true).'</p>';
 		$username =  '<form style="margin:0" method="post" action="./profile/"><button type="button" onclick="a(\'profile/'.$action["userName"].'\', true, true, \'POST\')" style="margin:0" class="accbtn" name="accountID">'.$action["userName"].'</button></form>';
 		$time = $this->convertToDate($action["uploadDate"], true);

--- a/incl/levelpacks/getGJLevelLists.php
+++ b/incl/levelpacks/getGJLevelLists.php
@@ -115,6 +115,8 @@ switch($type){
 		$params[] = "lists.accountID IN ($whereor)";
 		break;
 	case 7: // MAGIC
+	       	$order = "likes";
+		break;
 	case 27: // SENT
 		$params[] = "suggest.suggestLevelId < 0";
 		$order = "suggest.timestamp";

--- a/incl/lib/mainLib.php
+++ b/incl/lib/mainLib.php
@@ -39,11 +39,11 @@ class mainLib {
 			"Embers by Dex Arson",
 			"Round 1 by Dex Arson",
 			"Monster Dance Off by F-777",
- 		    "Press Start by MDK",
-   		    "Nock Em by Bossfight",
-  		    "Power Trip by Boom Kitty"];
-		if($id < 0 || $id >= count($songs))
-			return "Unknown by DJVI";
+ 		        "Press Start by MDK",
+   		        "Nock Em by Bossfight",
+  		        "Power Trip by Boom Kitty"];
+	        if ($id === -1) return "Practice: Stay Inside Me by OcularNebula";
+                if ($id < 0 || $id >= count($songs)) return "Unknown by DJVI";
 		return $songs[$id];
 	}
 	public function getDifficulty($diff, $auto, $demon, $demonDiff = 1) {


### PR DESCRIPTION
Added to "generateLevelsCard" the possibility to count the number of artists of NCS songs as on GD.

<img width="350" alt="Screenshot 2024-11-04 154420" src="https://github.com/user-attachments/assets/5e8ab485-9b56-42e8-998c-71a50867189f">
<img width="229" alt="Screenshot 2024-11-04 154254" src="https://github.com/user-attachments/assets/01edc330-5d5a-4094-820c-765a80ea2746">

Then I added "Stay Inside Me" if someone entered the value of audioTrack "-1", in the game it appears as the official song:

<img width="351" alt="Screenshot 2024-11-04 160725" src="https://github.com/user-attachments/assets/08966153-d9b1-4dfb-83d9-a0086b806be3">

Finally, not very relevant but as on vanilla the value of the lists on magic is the same as the high number of likes, which is I inserted it since nothing appeared on the server.


