### PR TITLE
/api/v1/songs/randomSong.php endpoint

### DIFF
--- a/api/v1/songs/random.php
+++ b/api/v1/songs/random.php
@@ -1,0 +1,12 @@
+<?php
+@header("Content-Type: application/json");
+header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Methods: GET");
+
+require_once __DIR__."/../../../incl/lib/mainLib.php";
+
+exit(json_encode([
+    "success" => true,
+    "song" => Library::randomSong()
+]));
+?>

--- a/incl/lib/mainLib.php
+++ b/incl/lib/mainLib.php
@@ -6144,5 +6144,30 @@ class Library {
 		
 		return "1:".$user["userName"].":2:".$user["userID"].":9:".$user['icon'].":10:".$user["color1"].":11:".$user["color2"].":14:".$user["iconType"].":15:".$user["special"].":16:".$user["extID"].":32:".$user["ID"].":35:".$user["comment"].":41:".$user["isNew"].":37:".$user['uploadTime'];
 	}
+
+	public static function randomSong() {
+		require_once __DIR__ . "/connection.php";
+		
+		$song = $db->prepare("SELECT ID, name, authorID, authorName, size, download, reuploadID, reuploadTime
+			FROM songs WHERE isDisabled = 0 AND download != 'CUSTOMURL'
+			ORDER BY RAND() ASC LIMIT 1");
+		$song->execute();
+		$song = $song->fetch();
+		
+		return [
+			"ID" => $song["ID"],
+			"name" => $song["name"],
+			"author" => [
+				"ID" => $song["authorID"],
+				"name" => $song["authorName"]
+			],
+			"size" => $song["size"],
+			"download" => $song["download"],
+			"reupload" => [
+				"ID" => $song["reuploadID"],
+				"time" => $song["reuploadTime"]
+			]
+		];
+	}
 }
 ?>


### PR DESCRIPTION
> [!WARNING]
> This is untested. For some reason, I was unable to get the new core running on my machine.

This pull requests introduces a new endpoint on `/api/v1/songs/randomSong.php`, allowing a random song to be chosen from a GDPS database:
```json
{
	"success": true,
	"song": {
		"ID": 12345,
		"name": "aaabbbcccddd",
		"author": {
			"ID": 12345,
			"name": "aaabbbcccddd"
		},
		"size": 12345,
		"download": "https://...",
		"reupload": {
			"ID": 12345,
			"time": 12345
		}
	}
}
```

This endpoint will be used on my [GDPS radio bot](https://github.com/M336G/gdps-radio-bot/) repository once this branch releases.